### PR TITLE
Make build more robust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -441,9 +441,7 @@ if not SKIP_CUDA_BUILD:
             url_func=lambda system, arch, version: f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",  # noqa: E501
         )
         base_dir = os.path.dirname(__file__)
-        ctk_path_new = os.path.join(
-            base_dir, os.pardir, "third_party", "nvidia", "backend", "bin"
-        )
+        ctk_path_new = os.path.abspath(os.path.join(base_dir, os.pardir, "third_party", "nvidia", "backend", "bin"))
         nvcc_path_new = os.path.join(ctk_path_new, f"nvcc{exe_extension}")
         # Need to append to path otherwise nvcc can't find cicc in nvvm/bin/cicc
         # nvcc 12.8 seems to hard-code looking for cicc in ../nvvm/bin/cicc

--- a/setup.py
+++ b/setup.py
@@ -441,7 +441,9 @@ if not SKIP_CUDA_BUILD:
             url_func=lambda system, arch, version: f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",  # noqa: E501
         )
         base_dir = os.path.dirname(__file__)
-        ctk_path_new = os.path.abspath(os.path.join(base_dir, os.pardir, "third_party", "nvidia", "backend", "bin"))
+        ctk_path_new = os.path.abspath(
+            os.path.join(base_dir, os.pardir, "third_party", "nvidia", "backend", "bin")
+        )
         nvcc_path_new = os.path.join(ctk_path_new, f"nvcc{exe_extension}")
         # Need to append to path otherwise nvcc can't find cicc in nvvm/bin/cicc
         # nvcc 12.8 seems to hard-code looking for cicc in ../nvvm/bin/cicc


### PR DESCRIPTION
This PR duplicates https://github.com/Dao-AILab/flash-attention/pull/1598 from the Flash Attention repo.
> In certain environments the relative path to the vendored nvcc is not picked up correctly if provided relative. In this PR, I just make it absolute.

It would be helpful to include here for ease of building :)