### PR TITLE
Removed causal mask enable env flag

### DIFF
--- a/magi_attention/__init__.py
+++ b/magi_attention/__init__.py
@@ -78,16 +78,6 @@ def is_refactor_bwd_args_enable() -> bool:
     return os.environ.get("MAGI_ATTENTION_REFACTOR_BWD_ARGS", "0") == "1"
 
 
-def is_causal_mask_enable() -> bool:
-    """
-    Toggle this env variable to 1 to allow causal mask
-    NOTE: This flag is only used during experimental stage
-    needed to be removed when causal mask is fully supported,
-    both in functionality and performance
-    """
-    return os.environ.get("MAGI_ATTENTION_SUPPORT_CAUSAL_MASK", "0") == "1"
-
-
 def is_cuda_device_max_connections_one() -> bool:
     """
     Toggle this env variable to 1 to allow cuda device to have only one connection

--- a/magi_attention/functional/flex_flash_attn.py
+++ b/magi_attention/functional/flex_flash_attn.py
@@ -355,7 +355,7 @@ def flex_flash_attn_func(
                 1 1 1 1 1
                 1 1 1 1 1
                 1 1 1 1 1
-        2: causal attention
+        2: causal attention (bottom-right aligned)
             If seqlen_q = 5 and seqlen_k = 2, the causal mask is:
                 0 0
                 0 0
@@ -371,7 +371,7 @@ def flex_flash_attn_func(
                 1 1 1 0 0
                 1 1 1 1 0
                 1 1 1 1 1
-        3: inverse causal attention
+        3: inverse causal attention (top-left aligned)
             if seqlen_q = 5 and seqlen_k = 2, the inverse causal mask is:
                 1 1
                 0 1
@@ -387,8 +387,8 @@ def flex_flash_attn_func(
                 0 0 1 1 1
                 0 0 0 1 1
                 0 0 0 0 1
-        4. bidirectional causal attention
-            bidirectional causal attention mask is a 'and mask' of casual and inverse causal attention.
+        4. bidirectional causal attention (top-left & bottom-right intersect-aligned)
+            bidirectional causal attention mask is an 'and mask' of casual and inverse causal attention.
             if seqlen_q = 5 and seqlen_k = 2, the bidirectional causal mask is:
                 0 0
                 0 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -42,12 +42,7 @@ from magi_attention.testing.precision import (
     extract_mismatch_info,
     torch_attn_ref,
 )
-from magi_attention.utils import (
-    get_attn_mask_from_ranges,
-    is_list_value_all,
-    str2seed,
-    sync_rng,
-)
+from magi_attention.utils import get_attn_mask_from_ranges, str2seed, sync_rng
 
 # tell if using profile mode
 profile_mode = os.environ.get("MAGI_ATTENTION_UNITEST_PROFILE_MODE", "0") == "1"
@@ -491,10 +486,7 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
                 is_causal_mapping = [
                     random.choice([True, False]) for _ in is_causal_mapping
                 ]
-        if not magi_attention.is_causal_mask_enable():
-            # NOTE: skip any test case with causal mask when the feature is disabled
-            if not is_list_value_all(is_causal_mapping, False):
-                return
+
         total_seqlen_q: int = attn_config["total_seqlen_q"]
         total_seqlen_k: int = attn_config["total_seqlen_k"]
         chunk_size: int = attn_config["chunk_size"]

--- a/tests/test_pipeline_sdpa.py
+++ b/tests/test_pipeline_sdpa.py
@@ -37,12 +37,7 @@ from magi_attention.dist_attn_runtime_mgr import DistAttnRuntimeMgr
 from magi_attention.testing import parameterize
 from magi_attention.testing.dist_common import DistTestBase, with_comms
 from magi_attention.testing.precision import EPSILON, torch_attn_ref
-from magi_attention.utils import (
-    get_attn_mask_from_ranges,
-    is_list_value_all,
-    str2seed,
-    sync_rng,
-)
+from magi_attention.utils import get_attn_mask_from_ranges, str2seed, sync_rng
 
 NAME = "name"
 SKIP_WORLD_SIZE = "skip_world_size"
@@ -584,10 +579,7 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                 is_causal_mapping = [
                     random.choice([True, False]) for _ in is_causal_mapping
                 ]
-        if not magi_attention.is_causal_mask_enable():
-            # NOTE: skip any test case with causal mask when the feature is disabled
-            if not is_list_value_all(is_causal_mapping, False):
-                return
+
         total_seqlen_q: int = attn_config["total_seqlen_q"]
         total_seqlen_k: int = attn_config["total_seqlen_k"]
         chunk_size: int = attn_config["chunk_size"]


### PR DESCRIPTION
* Removed `is_causal_mask_enable` env flag to enable causal testcases.
* Added the alignment info for three causal-style mask type in the ffa docstring.