### PR TITLE
Support overlapped q_ranges with all full mask

### DIFF
--- a/magi_attention/functional/dispatch.py
+++ b/magi_attention/functional/dispatch.py
@@ -52,13 +52,8 @@ def dispatch_func(
 
     # --------------      dispatch       -------------- #
 
-    x_split = torch.split(x_global, split_size_or_sections=meta.seqlens, dim=seq_dim)
-    x_perm = torch.concat(
-        [x_split[i] for i in meta.seqlens_perm_idxs],
-        dim=seq_dim,
-    )
     x_chunked = torch.chunk(
-        x_perm,
+        x_global,
         chunks=meta.num_chunks,
         dim=seq_dim,
     )
@@ -108,17 +103,8 @@ def undispatch_func(
         chunks=meta.num_chunks,
         dim=seq_dim,
     )
-    x_perm = torch.concat(
-        [x_chunked[i] for i in meta.partitions_unperm_idxs],
-        dim=seq_dim,
-    )
-    x_split = torch.split(
-        x_perm,
-        split_size_or_sections=meta.seqlens_permed,
-        dim=seq_dim,
-    )
     x_global = torch.concat(
-        [x_split[i] for i in meta.seqlens_unperm_idxs],
+        [x_chunked[i] for i in meta.partitions_unperm_idxs],
         dim=seq_dim,
     )
 

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -24,14 +24,11 @@ from magi_attention.comm.primitive import group_cast_collective, group_reduce_co
 from magi_attention.comm.work import WorkWithPostProcessFn
 from magi_attention.common.ranges import NaiveRanges
 from magi_attention.meta.collection import AttnCalcMeta, CommMeta
-from magi_attention.utils import nvtx, to_higher_fp_dtype
+from magi_attention.utils import max_fp_dtype, nvtx, to_higher_fp_dtype
 
 from .flex_flash_attn import _flex_flash_attn_backward, _flex_flash_attn_forward
 from .sdpa import sdpa_bwd, sdpa_fwd
 from .utils import safe_subtract
-
-# from flash_attn_interface import _flex_flash_attn_backward, _flex_flash_attn_forward
-
 
 logger = getLogger("magi_attention")
 
@@ -339,9 +336,19 @@ class DistFlashAttnRuntime:
                         sm_margin=0
                         if magi_attention.is_cuda_device_max_connections_one()
                         else 4,
-                        return_dtype=q.dtype,
-                        disable_fwd_atomic_reduction=True,
+                        # NOTE: increase the partial out precision temporarily,
+                        # to reduce the error caused by the out correction
+                        return_dtype=max_fp_dtype(q.dtype, torch.float32),
+                        disable_fwd_atomic_reduction=attn_arg.disable_fwd_atomic_reduction,
                     )
+
+                # DE-BUG: log fwd attn arg
+                # from magi_attention.utils import write_rank
+                # write_rank((
+                #     f"{attn_arg.q_ranges=}\n\n"
+                #     f"{attn_arg.k_ranges=}\n\n"
+                #     f"{attn_arg.to_ffa_args(is_bwd=False)=}\n\n"
+                # ), path="fwd_attn_arg.log")
 
                 # fill output with zero indexed by "hole" q ranges
                 # TODO: put this logic into kernel
@@ -561,6 +568,10 @@ class DistFlashAttnFunc(torch.autograd.Function):
             #       and once gradients between different tokens need to be reduced, the nan values
             #       from pad tokens would interfere with the gradients of other tokens
             out = torch.zeros_like(local_q)
+        else:
+            # NOTE: since we've increased the precision of partial out for correction
+            # here we need to downcast to q dtype to both return and save for backward
+            out = out.to(local_q.dtype)
 
         ctx.save_for_backward(local_q, local_kv, out, lse)
         ctx.dist_attn_runtime = dist_attn_runtime

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -342,14 +342,6 @@ class DistFlashAttnRuntime:
                         disable_fwd_atomic_reduction=attn_arg.disable_fwd_atomic_reduction,
                     )
 
-                # DE-BUG: log fwd attn arg
-                # from magi_attention.utils import write_rank
-                # write_rank((
-                #     f"{attn_arg.q_ranges=}\n\n"
-                #     f"{attn_arg.k_ranges=}\n\n"
-                #     f"{attn_arg.to_ffa_args(is_bwd=False)=}\n\n"
-                # ), path="fwd_attn_arg.log")
-
                 # fill output with zero indexed by "hole" q ranges
                 # TODO: put this logic into kernel
                 out_zero_fill_correction(out, attn_arg.out_zero_fill_ranges)

--- a/magi_attention/meta/collection/calc_meta.py
+++ b/magi_attention/meta/collection/calc_meta.py
@@ -28,7 +28,7 @@ class AttnArg:
     q_ranges: AttnRanges
     k_ranges: AttnRanges
     is_causal_mapping: list[bool]
-    # attn_type_map: torch.Tensor
+
     # REVIEW(xiaowu): Is shard_seqlen_q an appropriate name?
     shard_seqlen_q: int
 
@@ -104,23 +104,20 @@ class AttnArg:
             )
 
     def _init_out_zero_fill_ranges(self) -> None:
-        start, end = 0, self.shard_seqlen_q
-        out_zero_fill_ranges: list[tuple[int, int]] = []
-        for q_range in self.q_ranges:
-            if start < q_range.start:
-                out_zero_fill_ranges.append((start, q_range.start))
-            start = q_range.end
-        if start < end:
-            out_zero_fill_ranges.append((start, end))
-
-        self.out_zero_fill_ranges = (
-            AttnRanges.from_ranges(out_zero_fill_ranges).merge().to_naive_ranges()
-        )
+        shard_q_ranges = AttnRanges.from_ranges([[0, self.shard_seqlen_q]])
+        self.out_zero_fill_ranges = AttnRanges.find_hole_ranges(
+            shard_q_ranges,
+            self.q_ranges,
+            is_self_merged=True,
+        ).to_naive_ranges()
 
     def _init_ffa_fwd_args_dict(self) -> None:
-        # init skip attn flag
+        # init `skip_attn_fwd` flag
         batch_size_fwd = len(self.q_ranges)
         self.skip_attn_fwd = batch_size_fwd == 0
+
+        # init `disable_fwd_atomic_reduction` flag
+        self.disable_fwd_atomic_reduction = self.q_ranges.is_non_overlap()
 
         # init tensors
         q_ranges_tensor_fwd = self.q_ranges.to_tensor(
@@ -129,11 +126,6 @@ class AttnArg:
         k_ranges_tensor_fwd = self.k_ranges.to_tensor(
             device=torch.cuda.current_device()
         )
-        """
-        is_causal_mapping_tensor_fwd = torch.tensor(
-            self.is_causal_mapping, dtype=torch.bool, device=torch.cuda.current_device()
-        )
-        """
         mask_type_tensor_fwd = torch.tensor(
             self.is_causal_mapping,
             dtype=torch.int32,
@@ -147,9 +139,6 @@ class AttnArg:
                 assert q_ranges_tensor_fwd.shape == torch.Size([batch_size_fwd, 2])
                 assert k_ranges_tensor_fwd.shape == torch.Size([batch_size_fwd, 2])
                 assert mask_type_tensor_fwd.shape == torch.Size([batch_size_fwd])
-                # assert attn_type_map_fwd.shape == torch.Size(
-                #    [batch_size_fwd]
-                # )
 
         # init max seqlen
         if self.skip_attn_fwd:  # no calc needed
@@ -162,8 +151,6 @@ class AttnArg:
         self.ffa_fwd_args_dict = dict(
             q_ranges=q_ranges_tensor_fwd,
             k_ranges=k_ranges_tensor_fwd,
-            # XXX HACK: for latest ffa interface
-            # is_causal_mapping=is_causal_mapping_tensor_fwd,
             attn_type_map=mask_type_tensor_fwd,
             max_seqlen_q=max_seqlen_q_fwd,
             max_seqlen_k=max_seqlen_k_fwd,
@@ -191,8 +178,6 @@ class AttnArg:
             k_ranges_tensor_bwd = self.k_ranges_bwd.to_tensor(
                 device=torch.cuda.current_device()
             )
-
-            # XXX HACK: for latest ffa interface
             mask_type_tensor_bwd = torch.tensor(
                 self.is_causal_mapping_bwd,
                 dtype=torch.int32,
@@ -218,8 +203,6 @@ class AttnArg:
             self.ffa_bwd_args_dict = dict(
                 q_ranges=q_ranges_tensor_bwd,
                 k_ranges=k_ranges_tensor_bwd,
-                # XXX HACK: for latest ffa interface
-                # is_causal_mapping=is_causal_mapping_tensor_bwd,
                 attn_type_map=mask_type_tensor_bwd,
                 max_seqlen_q=max_seqlen_q_bwd,
                 max_seqlen_k=max_seqlen_k_bwd,
@@ -227,10 +210,11 @@ class AttnArg:
         else:
             # just copy args from fwd
             self.skip_attn_bwd = self.skip_attn_fwd
-            self.ffa_bwd_args_dict = self.ffa_fwd_args_dict
             self.q_ranges_bwd = self.q_ranges
             self.k_ranges_bwd = self.k_ranges
             self.is_causal_mapping_bwd = self.is_causal_mapping
+
+            self.ffa_bwd_args_dict = self.ffa_fwd_args_dict
 
     def _refactor_bwd_ranges_and_types(
         self,

--- a/magi_attention/meta/collection/calc_meta.py
+++ b/magi_attention/meta/collection/calc_meta.py
@@ -99,7 +99,9 @@ class AttnArg:
                 assert not k_range.is_empty()
 
             # check non-overlapped q ranges
-            assert self.q_ranges.is_non_overlap()
+            assert self.q_ranges.is_non_overlap() or is_list_value_all(
+                self.is_causal_mapping, False
+            )
 
     def _init_out_zero_fill_ranges(self) -> None:
         start, end = 0, self.shard_seqlen_q

--- a/magi_attention/meta/collection/dispatch_meta.py
+++ b/magi_attention/meta/collection/dispatch_meta.py
@@ -50,14 +50,6 @@ class DispatchMeta:
     cp_rank: int
     cp_size: int
 
-    seqlens: list[int]
-    seqlens_permed: list[int]  # used but not enabled property
-    seqlens_perm_idxs: list[int]  # used but not enabled property
-    seqlens_unperm_idxs: list[int]  # used but not enabled property
-
-    cu_seqlens: list[int]  # unused property
-    cu_seqlens_permed: list[int]  # unused property
-
     # dispatch solver results
     partitions: list[list[int]]
     partitions_perm_idxs: list[int]
@@ -119,16 +111,6 @@ class DispatchMeta:
         return position_ids
 
     def __post_init__(self) -> None:
-        assert len(self.seqlens) == len(self.seqlens_permed) == self.batch_size
-        assert (
-            len(self.seqlens_perm_idxs)
-            == len(self.seqlens_unperm_idxs)
-            == self.batch_size
-        )
-        assert (
-            len(self.cu_seqlens) == len(self.cu_seqlens_permed) == self.batch_size + 1
-        )
-
         assert len(self.partitions) == self.cp_size
         assert (
             len(self.partitions_perm_idxs)

--- a/magi_attention/meta/solver/dist_attn_solver.py
+++ b/magi_attention/meta/solver/dist_attn_solver.py
@@ -1693,16 +1693,11 @@ class DistAttnSolver:
                 is_self_merged=True,
             ).merge()
 
-            if magi_attention.is_sanity_check_enable():
-                # the local ranges are always contains only a single range after merged
-                # unless the it is empty
-                assert len(k_ranges) <= 1
-
-            if len(k_ranges) == 1:
+            for k_range in k_ranges:
                 attn_calc_remote_slice_local_list_this_stage.append(
                     AttnSlice(
                         q_range=q_range,
-                        k_range=k_ranges[0],
+                        k_range=k_range,
                         mask_type=mask_type,
                     )
                 )

--- a/magi_attention/testing/utils.py
+++ b/magi_attention/testing/utils.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from magi_attention.common import AttnRange
+from magi_attention.common.enum import AttnMaskType
+
+
+def add_range_to_array(
+    array: np.ndarray,
+    q_range: AttnRange,
+    k_range: AttnRange,
+    masktype: AttnMaskType = AttnMaskType.FULL,
+    check: bool = False,
+):
+    # get start and end of range
+    x_start, x_end = q_range.start, q_range.end
+    y_start, y_end = k_range.start, k_range.end
+
+    if check:
+        # check whether the current slice has been filled
+        assert np.all(array[x_start:x_end, y_start:y_end] == 0), (
+            f"Part of the area has been added," f"when {q_range=} and {k_range=}"
+        )
+
+    # fill the area according to the type of the mask.
+    for i in range(x_start, x_end):
+        for j in range(y_start, y_end):
+            if masktype == AttnMaskType.FULL:
+                array[i][j] = 1
+            elif masktype == AttnMaskType.CAUSAL:
+                b = y_end - x_end
+                fx = i + b
+                if j <= fx:
+                    array[i][j] = 1
+                else:
+                    array[i][j] = 0
+            # HACK do not support INV_CAUSAL and BI_CAUSAL now
+            # elif masktype == AttnMaskType.INV_CAUSAL:
+            #     b = y_start - x_start
+            #     fx = i + b
+            #     if j >= fx:
+            #         array[i][j] = 1
+            #     else:
+            #         array[i][j] = 0
+            # elif masktype == AttnMaskType.BI_CAUSAL:
+            #     causal_b = y_end - x_end
+            #     f_causal = i + causal_b
+
+            #     inv_causal_b = y_start - x_start
+            #     f_inv_causal = i + inv_causal_b
+            #     if j <= f_causal and j >= f_inv_causal:
+            #         array[i][j] = 1
+            #     else:
+            #         array[i][j] = 0
+
+    return array

--- a/magi_attention/utils/_utils.py
+++ b/magi_attention/utils/_utils.py
@@ -58,7 +58,9 @@ def deprecated(func: Callable) -> Callable:
 
 
 def rprint_rank(
-    msg: str, rank: int | None = None, width: int = 50
+    msg: str,
+    rank: int | None = None,
+    width: int = 50,
 ) -> None:  # pragma: no cover
     if rank is None or dist.get_rank() == rank:
         rank = dist.get_rank()
@@ -69,7 +71,10 @@ def rprint_rank(
 
 
 def write_rank(
-    msg: str, path: str, rank: int | None = None, width: int = 50
+    msg: str,
+    path: str,
+    rank: int | None = None,
+    width: int = 50,
 ) -> None:  # pragma: no cover
     if rank is None or dist.get_rank() == rank:
         rank = dist.get_rank()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -824,7 +824,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
         out_ref_norm = calc_inf_norm(
             total_out_ref_low_precision, total_out_ref_high_precision
         )
-
         self.assertLessEqual(
             out_norm,
             norm_rtol_ratio * out_ref_norm,
@@ -839,7 +838,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             rtol=o_rtol,
             mismatch_thres_ratio=mismatch_thres_ratio,
         )
-
         magi_attention.testing.assert_close(
             total_out,
             total_out_ref_high_precision,
@@ -856,7 +854,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
         dq_ref_norm = calc_inf_norm(
             grad_total_q_ref_low_precision, grad_total_q_ref_high_precision
         )
-
         self.assertLessEqual(
             dq_norm,
             norm_rtol_ratio * dq_ref_norm,
@@ -871,7 +868,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             rtol=dq_rtol,
             mismatch_thres_ratio=mismatch_thres_ratio,
         )
-
         magi_attention.testing.assert_close(
             grad_total_q,
             grad_total_q_ref_high_precision,
@@ -888,7 +884,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
         dk_ref_norm = calc_inf_norm(
             grad_total_k_ref_low_precision, grad_total_k_ref_high_precision
         )
-
         self.assertLessEqual(
             dk_norm,
             norm_rtol_ratio * dk_ref_norm,
@@ -903,7 +898,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             rtol=dk_rtol,
             mismatch_thres_ratio=mismatch_thres_ratio,
         )
-
         magi_attention.testing.assert_close(
             grad_total_k,
             grad_total_k_ref_high_precision,
@@ -934,7 +928,6 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             rtol=dv_rtol,
             mismatch_thres_ratio=mismatch_thres_ratio,
         )
-
         magi_attention.testing.assert_close(
             grad_total_v,
             grad_total_v_ref_high_precision,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -267,6 +267,67 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
                 "total_seqlen_k": 10240,
                 "chunk_size": 512,
             },
+            # varlen block causal with total seqlen 12k + overlapped q ranges
+            {
+                NAME: "varlen_block_causal_12k_with_q_overlap",
+                SKIP_WORLD_SIZE: [5, 7],
+                "q_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 8192],
+                        [2048, 8192],
+                        [4096, 8192],
+                        [6144, 8192],
+                        [8192, 12288],
+                        [10240, 12288],
+                    ]
+                ),
+                "k_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 2048],
+                        [2048, 4096],
+                        [4096, 6144],
+                        [6144, 8192],
+                        [8192, 10240],
+                        [10240, 12288],
+                    ]
+                ),
+                "is_causal_mapping": [False] * 6,
+                "total_seqlen_q": 12288,
+                "total_seqlen_k": 12288,
+                "chunk_size": 512,
+            },
+            # half-inv block diagonal with total seqlen 10k
+            # + interleaved overlapped q ranges
+            {
+                NAME: "varlen_block_causal_12k_with_q_overlap",
+                SKIP_WORLD_SIZE: [2, 4, 5, 6, 8],
+                "q_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 3072],
+                        [1536, 4608],
+                        [3072, 6144],
+                        [4608, 7680],
+                        [6144, 9216],
+                        [7680, 10752],
+                        [9216, 10752],
+                    ]
+                ),
+                "k_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 1536],
+                        [1536, 3072],
+                        [3072, 4608],
+                        [4608, 6144],
+                        [6144, 7680],
+                        [7680, 9216],
+                        [9216, 10752],
+                    ]
+                ),
+                "is_causal_mapping": [False] * 7,
+                "total_seqlen_q": 10752,
+                "total_seqlen_k": 10752,
+                "chunk_size": 512,
+            },
             # NOTE: profile only case
             # full attn with total seqlen 140k
             # {

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -825,35 +825,11 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             total_out_ref_low_precision, total_out_ref_high_precision
         )
 
-        # DE-BUG: log out with ref
-        # from magi_attention.utils import write_rank
-        # write_rank((
-        #     f"{test_case=}\n\n"
-        #     f"{total_out=}\n\n"
-        #     f"{total_out_ref_high_precision=}\n\n"
-        # ), path="test_pipe_out.log")
-
-        # try:
-        #     torch.testing.assert_close(
-        #         total_out,
-        #         total_out_ref_high_precision,
-        #         atol=o_atol,
-        #         rtol=o_rtol,
-        #     )
-        # except AssertionError as e:
-        #     write_rank((
-        #         f"Torch Error:\n\n{e}\n\n"
-        #     ), path="test_pipe_out_torch_assertclose.log")
-
-        if "q_overlap" not in test_case:
-            # XXX: with overlapped q ranges, the out Linf norm test cannot pass
-            # espeicially when dtype is bfloat16, and the total seqlen is quite long
-            # which seems like a bug about the atomic-reduction of out in the ffa fwd kernel
-            self.assertLessEqual(
-                out_norm,
-                norm_rtol_ratio * out_ref_norm,
-                msg=f"For {test_case=}: {out_norm=} should be no greater than {norm_rtol_ratio}x of {out_ref_norm=}",
-            )
+        self.assertLessEqual(
+            out_norm,
+            norm_rtol_ratio * out_ref_norm,
+            msg=f"For {test_case=}: {out_norm=} should be no greater than {norm_rtol_ratio}x of {out_ref_norm=}",
+        )
 
         # torch style with atol + rtol + mismatch threshold
         o_thres = self._extract_mismatch_threshold_ref(
@@ -881,15 +857,11 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             grad_total_q_ref_low_precision, grad_total_q_ref_high_precision
         )
 
-        if "q_overlap" not in test_case:
-            # XXX: with overlapped q ranges, the dq Linf norm test cannot pass due to out
-            # espeicially when dtype is bfloat16, and the total seqlen is quite long
-            # which seems like a bug about the atomic-reduction of out in the ffa fwd kernel
-            self.assertLessEqual(
-                dq_norm,
-                norm_rtol_ratio * dq_ref_norm,
-                msg=f"For {test_case=}: {dq_norm=} should be no greater than {norm_rtol_ratio}x of {dq_ref_norm=}",
-            )
+        self.assertLessEqual(
+            dq_norm,
+            norm_rtol_ratio * dq_ref_norm,
+            msg=f"For {test_case=}: {dq_norm=} should be no greater than {norm_rtol_ratio}x of {dq_ref_norm=}",
+        )
 
         # torch style with atol + rtol + mismatch threshold
         dq_thres = self._extract_mismatch_threshold_ref(
@@ -917,15 +889,11 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             grad_total_k_ref_low_precision, grad_total_k_ref_high_precision
         )
 
-        if "q_overlap" not in test_case:
-            # XXX: with overlapped q ranges, the dk Linf norm test cannot pass due to out
-            # espeicially when dtype is bfloat16, and the total seqlen is quite long
-            # which seems like a bug about the atomic-reduction of out in the ffa fwd kernel
-            self.assertLessEqual(
-                dk_norm,
-                norm_rtol_ratio * dk_ref_norm,
-                msg=f"For {test_case=}: {dk_norm=} should be no greater than {norm_rtol_ratio}x of {dk_ref_norm=}",
-            )
+        self.assertLessEqual(
+            dk_norm,
+            norm_rtol_ratio * dk_ref_norm,
+            msg=f"For {test_case=}: {dk_norm=} should be no greater than {norm_rtol_ratio}x of {dk_ref_norm=}",
+        )
 
         # torch style with atol + rtol + mismatch threshold
         dk_thres = self._extract_mismatch_threshold_ref(

--- a/tests/test_pipeline_sdpa.py
+++ b/tests/test_pipeline_sdpa.py
@@ -574,6 +574,67 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                 "total_seqlen_k": 1024,
                 "chunk_size": 128,
             },
+            # varlen block causal with total seqlen 840 + overlapped q ranges
+            {
+                NAME: "varlen_block_causal_840_with_q_overlap",
+                SKIP_WORLD_SIZE: [4, 8],
+                "q_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 512],
+                        [128, 512],
+                        [256, 512],
+                        [384, 512],
+                        [512, 840],
+                        [640, 840],
+                        [768, 840],
+                    ]
+                ),
+                "k_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 128],
+                        [128, 256],
+                        [256, 384],
+                        [384, 512],
+                        [512, 640],
+                        [640, 768],
+                        [768, 840],
+                    ]
+                ),
+                "is_causal_mapping": [False] * 7,
+                "total_seqlen_q": 840,
+                "total_seqlen_k": 840,
+                "chunk_size": 4,
+            },
+            # half-inv block diagonal with total seqlen 1050
+            # + interleaved overlapped q ranges
+            {
+                NAME: "half_inv_block_diagonal_1050_with_interleave_q_overlap",
+                SKIP_WORLD_SIZE: [4, 8],
+                "q_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 420],
+                        [210, 630],
+                        [420, 840],
+                        [630, 1050],
+                        [0, 210],
+                        [840, 1050],
+                    ]
+                ),
+                "k_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 210],
+                        [210, 420],
+                        [420, 630],
+                        [630, 840],
+                        [840, 1050],
+                        [840, 1050],
+                    ]
+                ),
+                "is_causal_mapping": [False] * 6,
+                "total_seqlen_q": 1050,
+                "total_seqlen_k": 1050,
+                "chunk_size": 5,
+            },
         ],
     )
     @parameterize(

--- a/tests/test_pipeline_sdpa.py
+++ b/tests/test_pipeline_sdpa.py
@@ -429,9 +429,9 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                 "total_seqlen_k": 1024,
                 "chunk_size": 128,
             },
-            # share question mask with total seqlen 1k
+            # share question mask with total seqlen 1k + overlapped q ranges
             {
-                NAME: "share_question_mask_1k",
+                NAME: "share_question_1k_with_q_overlap",
                 SKIP_WORLD_SIZE: [3, 5, 6, 7],
                 "q_ranges": AttnRanges.from_ranges(
                     [
@@ -454,9 +454,10 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                 "total_seqlen_k": 1024,
                 "chunk_size": 128,
             },
-            # interleaved q_range mask with total seqlen 1k
+            # half-inv block diagonal with total seqlen 1k
+            # + interleaved overlapped q ranges
             {
-                NAME: "shark_overlap_mask_1k",
+                NAME: "half_inv_block_diagonal_1k_with_interleave_q_overlap",
                 SKIP_WORLD_SIZE: [3, 5, 6, 7],
                 "q_ranges": AttnRanges.from_ranges(
                     [
@@ -501,9 +502,9 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                 "total_seqlen_k": 1024,
                 "chunk_size": 128,
             },
-            # block causal in overlap q_range with 1k mask
+            # varlen block causal with total seqlen 1k + overlapped q ranges
             {
-                NAME: "block_causal_in_overlap_mask_1k",
+                NAME: "varlen_block_causal_1k_with_q_overlap",
                 SKIP_WORLD_SIZE: [3, 5, 6, 7],
                 "q_ranges": AttnRanges.from_ranges(
                     [
@@ -725,7 +726,7 @@ class TestPipelineSDPABaseWithWorldSize1(DistTestBase):
                     random.choice([True, False]) for _ in is_causal_mapping
                 ]
 
-        # -----    skip for q_range overlap with causal mask  ---- #
+        # -----    skip for overlapped q_range with causal mask  ---- #
 
         if not q_ranges.is_non_overlap() and not is_list_value_all(
             is_causal_mapping, False


### PR DESCRIPTION
#### DONE
- supported overlapped q_ranges when all mask types for attn slices are `FULL`.
- added uni-test cases for overlapped q_ranges in `test_pipeline.py` and `test_pipeline_sdpa.py`.
- auto set the `disable_fwd_atomic_reduction` in `AttnArg` initialization.
- increased the partial out precision to at least `float32` to reduce the correction error, aligned with the fwd epilogue within the ffa kernel.
- fixed the bug related to the atomic reduction of the out correction in the ffa fwd kernel, caused by unsafe memory order instructions.