### PR TITLE
Add megatron example

### DIFF
--- a/example/megatron/README.md
+++ b/example/megatron/README.md
@@ -1,5 +1,9 @@
-## Intergrate with magiattention with megatron
-Example of intergrating magiattention with megatron is comming soon.
+## Intergrate magiattention with megatron
+We fork a repo of megatron and show how to intergrate MagiAttention with Megatron.
+
+You can refer to  https://github.com/hanwen-sun/Megatron-LM/pull/2 for more information.
 
 ## High-Precision Alignment
-The experiment of high-precision alignment with torch native model training(single gpu) is comming soon to ensure correctness of magiattention.
+We train llama-1b model from scratch with MagiAttention and compare the training loss convergence curve with te context parallel:
+![alt text](./results.png)
+You can refer to https://github.com/hanwen-sun/Megatron-LM/pull/2 for more infromation.

--- a/magi_attention/api/magi_attn_interface.py
+++ b/magi_attention/api/magi_attn_interface.py
@@ -330,6 +330,8 @@ def magi_attn_flex_key(
     if head_dim > 192:
         raise ValueError(f"head_dim ({head_dim}) must be ≤ 192")
 
+    attn_mask_type = wrap_to_list(attn_mask_type, broadcast_to_length=q_ranges.size)
+
     assert (
         is_list_value_all(attn_mask_type, AttnMaskType.FULL)  # type: ignore[arg-type]
         or q_ranges.is_non_overlap()
@@ -337,8 +339,6 @@ def magi_attn_flex_key(
         "Only support q_range overlap when masktype is all full, "
         "other masktype is not supported for now."
     )
-
-    attn_mask_type = wrap_to_list(attn_mask_type, broadcast_to_length=q_ranges.size)
 
     if is_list_value_any(attn_mask_type, AttnMaskType.BICAUSAL):
         raise ValueError(


### PR DESCRIPTION
What this pr do:
- add megatron example:
  -  We fork a repo of megatron and show how to integrate magiattention with megatron.
  -  We train llama-1b from scratch with magiattention and compare the loss convergence curve with te context parallel to show the correctness of magiattention.
 
feel free to open any issue in the megatron example repo if you have any question.