### PR TITLE
Fix ffa bwd "bug" related to CUDA kernel gridDim size limitation

### DIFF
--- a/magi_attention/csrc/flexible_flash_attention/flash_bwd_preprocess_kernel.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_bwd_preprocess_kernel.h
@@ -150,9 +150,18 @@ public:
         static constexpr int kBlockM = get<0>(TileShape_MK{});
 
         int const thread_idx = threadIdx.x;
-        int const m_block = blockIdx.x;
-        int const bidh = blockIdx.y;
-        int const bidb = blockIdx.z;
+
+        /**
+         * NOTE: Here, we shift the batch size to the x-dimension because the z-dimension must be less than 65536.
+         *  Thus once the batch size is too large (>= 65536), the z-dimension may overflow, causing an implicit kernel-launch error.
+         *  What's worse, this error may not be explicitly raised, resulting in the kernel being skipped.
+         */
+        // int const m_block = blockIdx.x;
+        // int const bidh = blockIdx.y;
+        // int const bidb = blockIdx.z;
+        int const m_block = blockIdx.y;
+        int const bidh = blockIdx.z;
+        int const bidb = blockIdx.x;
 
         flash::SeqlenInfoBwd<Varlen, kBlockM> seqlen_info(bidb, size<0>(params.shape_O), params.cu_seqlens, params.ranges, params.seqused);
         bool const is_varlen = Varlen && (params.cu_seqlens || params.ranges);

--- a/magi_attention/testing/precision.py
+++ b/magi_attention/testing/precision.py
@@ -109,9 +109,14 @@ def torch_attn_ref(
                 k.to(torch.float64),
                 v.to(torch.float64),
                 attn_mask=mask,
+                enable_gqa=True,
             )
         else:
-            out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
+            out = F.scaled_dot_product_attention(
+                q, k, v, 
+                attn_mask=mask,
+                enable_gqa=True,
+            )
 
     if layout == "thd":
         out = rearrange(out, "1 h t d -> t h d")

--- a/magi_attention/testing/precision.py
+++ b/magi_attention/testing/precision.py
@@ -113,7 +113,9 @@ def torch_attn_ref(
             )
         else:
             out = F.scaled_dot_product_attention(
-                q, k, v, 
+                q,
+                k,
+                v,
                 attn_mask=mask,
                 enable_gqa=True,
             )

--- a/magi_attention/testing/precision.py
+++ b/magi_attention/testing/precision.py
@@ -43,6 +43,24 @@ def extract_mismatch_info(error_msg: str) -> tuple[int, int, float]:
         raise ValueError(f"Could not find mismatch elements in {error_msg=}")
 
 
+def extract_mismatch_threshold(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    atol: float,
+    rtol: float,
+    mismatch_thres_ratio: float = 1.0,
+) -> float:
+    mismatch_threshold = 0.0
+    try:
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    except AssertionError as e:
+        error_msg = str(e)
+        _, _, mismatch_threshold = extract_mismatch_info(error_msg)
+
+    # scale it by `mismatch_thres_ratio`, and clamp it in [0, 1]
+    return min(max(mismatch_threshold * mismatch_thres_ratio, 0.0), 1.0)
+
+
 def assert_close(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,8 @@ classifiers = [
 profile = "black"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "build"]
+requires = ["setuptools>=61.0", "wheel", "build", "versioningit"]
 build-backend = "setuptools.build_meta"
+
+[tool.versioningit]
+vcs = "git"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# TODO: add ffa
 rich
+versioningit

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 import sysconfig
 import tarfile
-import urllib.error
 import urllib.request
 import warnings
 from pathlib import Path
@@ -63,6 +62,8 @@ SKIP_CUDA_BUILD = os.getenv("MAGI_ATTENTION_SKIP_CUDA_BUILD", "FALSE") == "TRUE"
 FORCE_CXX11_ABI = os.getenv("MAGI_ATTENTION_FORCE_CXX11_ABI", "FALSE") == "TRUE"
 
 
+# TODO: remove flags to compile with sm80
+# which we do not support for now
 def _write_ninja_file(
     path,
     cflags,
@@ -612,7 +613,6 @@ if not SKIP_CUDA_BUILD:
 
 setup(
     name="magi_attention",
-    version="1.0.0",
     packages=find_packages(
         exclude=(
             "build",

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -12,4 +12,410 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add UT as soon as possible
+
+import unittest
+from typing import Any
+from unittest import TestCase
+
+import torch
+
+import magi_attention
+from magi_attention.common import AttnRanges
+from magi_attention.functional import flex_flash_attn_func
+from magi_attention.testing import parameterize
+from magi_attention.testing.precision import (
+    EPSILON,
+    calc_inf_norm,
+    extract_mismatch_info,
+    torch_attn_ref,
+)
+from magi_attention.utils import get_attn_mask_from_ranges, is_list_value_any
+
+
+class TestFlexFlashAttn(TestCase):
+    @property
+    def seed(self):
+        return 42
+
+    @property
+    def device(self):
+        return torch.cuda.current_device()
+
+    @parameterize(
+        "attn_mask_config",
+        [
+            {
+                "name": "varlen_full_2k",
+                "seqlen": 2048,
+                "q_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 256],
+                        [256, 512],
+                        [512, 1024],
+                        [1024, 1280],
+                        [1280, 1536],
+                        [1536, 1792],
+                        [1792, 2048],
+                    ]
+                ),
+                "k_ranges": AttnRanges.from_ranges(
+                    [
+                        [0, 256],
+                        [0, 512],
+                        [0, 1024],
+                        [0, 1280],
+                        [0, 1536],
+                        [0, 1792],
+                        [0, 2048],
+                    ],
+                ),
+                "attn_type_map": [0, 0, 0, 0, 0, 0, 0],
+            },
+        ],
+    )
+    @parameterize(
+        "model_config",
+        [
+            {
+                "name": "mha_nh8_hd128",
+                "num_heads_q": 8,
+                "num_heads_kv": 8,
+                "head_dim": 128,
+            },
+            {
+                "name": "gqa_nhq48_nhkv8_hd128",
+                "num_heads_q": 48,
+                "num_heads_kv": 8,
+                "head_dim": 128,
+            },
+            {
+                "name": "mha_nh1_hd64",
+                "num_heads_q": 1,
+                "num_heads_kv": 1,
+                "head_dim": 64,
+            },
+            {
+                "name": "gqa_nhq4_nhkv2_hd64",
+                "num_heads_q": 4,
+                "num_heads_kv": 2,
+                "head_dim": 64,
+            },
+        ],
+    )
+    @parameterize("dtype", [torch.float16, torch.bfloat16])
+    def test_flex_attn(
+        self,
+        attn_mask_config: dict[str, Any],
+        model_config: dict[str, Any],
+        dtype,
+    ):
+        assert not is_list_value_any(
+            attn_mask_config["attn_type_map"], 2
+        ) and not is_list_value_any(attn_mask_config["attn_type_map"], 3), (
+            "(TODO) For now, we skip test cases with attn_type_map containing 2 or 3, "
+            "because they are not supported in `torch_attn_ref`"
+        )
+
+        torch.manual_seed(self.seed)
+
+        # extract config
+        seqlen = attn_mask_config["seqlen"]
+        q_ranges: AttnRanges = attn_mask_config["q_ranges"]
+        k_ranges: AttnRanges = attn_mask_config["k_ranges"]
+        attn_type_map: list[int] = attn_mask_config["attn_type_map"]
+
+        num_heads_q = model_config["num_heads_q"]
+        num_heads_kv = model_config["num_heads_kv"]
+        head_dim = model_config["head_dim"]
+
+        test_case = f"[{attn_mask_config['name']}][{model_config['name']}][{dtype}]"
+
+        # construct data
+        q = torch.randn(
+            (seqlen, num_heads_q, head_dim), dtype=dtype, device=self.device,
+            requires_grad = True,
+        )
+        k = torch.randn(
+            (seqlen, num_heads_kv, head_dim), dtype=dtype, device=self.device,
+            requires_grad = True,
+        )
+        v = torch.randn(
+            (seqlen, num_heads_kv, head_dim), dtype=dtype, device=self.device,
+            requires_grad = True,
+        )
+        do = torch.randn_like(q)
+
+        # construct meta args
+        max_seqlen_q = q_ranges.max_seqlen
+        max_seqlen_k = k_ranges.max_seqlen
+        q_ranges_tensor = q_ranges.to_tensor(device=self.device)
+        k_ranges_tensor = k_ranges.to_tensor(device=self.device)
+        attn_type_map_tensor = torch.tensor(
+            attn_type_map, dtype=torch.int32, device=self.device
+        )
+
+        # run ffa forward
+        o, _ = flex_flash_attn_func(
+            q,
+            k,
+            v,
+            q_ranges_tensor,
+            k_ranges_tensor,
+            max_seqlen_q,
+            max_seqlen_k,
+            attn_type_map_tensor,
+        )
+        o.backward(do)
+
+        # compare with reference
+        self.assert_close_to_torch_ref(
+            q_ranges=q_ranges,
+            k_ranges=k_ranges,
+            attn_type_map=attn_type_map,
+            total_seqlen_q=seqlen,
+            total_seqlen_k=seqlen,
+            total_q=q,
+            total_k=k,
+            total_v=v,
+            total_out=o,
+            grad_total_q=q.grad,
+            grad_total_k=k.grad,
+            grad_total_v=v.grad,
+            grad_total_out=do,
+            dtype=dtype,
+            test_case=test_case,
+        )
+
+    def assert_close_to_torch_ref(
+        self,
+        q_ranges: AttnRanges,
+        k_ranges: AttnRanges,
+        attn_type_map: list[int],
+        total_seqlen_q: int,
+        total_seqlen_k: int,
+        total_q: torch.Tensor,
+        total_k: torch.Tensor,
+        total_v: torch.Tensor,
+        total_out: torch.Tensor,
+        grad_total_q: torch.Tensor,
+        grad_total_k: torch.Tensor,
+        grad_total_v: torch.Tensor,
+        grad_total_out: torch.Tensor,
+        dtype: torch.dtype,
+        test_case: str = "",
+    ) -> None:
+        # -----   customize tolerance threshold  ---- #
+
+        o_atol = EPSILON
+        o_rtol = {torch.bfloat16: 0.05, torch.float16: 0.05}.get(dtype, 0.05)
+
+        dq_atol = EPSILON
+        dq_rtol = {torch.bfloat16: 0.3, torch.float16: 0.2}.get(dtype, 0.2)
+
+        dk_atol = EPSILON
+        dk_rtol = {torch.bfloat16: 0.15, torch.float16: 0.08}.get(dtype, 0.08)
+
+        dv_atol = EPSILON
+        dv_rtol = {torch.bfloat16: 0.05, torch.float16: 0.05}.get(dtype, 0.05)
+
+        # NOTE: an experimental value from magi_attention testing
+        mismatch_thres_ratio: float = 2.0
+        # NOTE: an experimental value from fa testing
+        norm_rtol_ratio: float = 2.0
+
+        # -----   build attn mask   ---- #
+
+        mask = get_attn_mask_from_ranges(
+            q_ranges=q_ranges.to_naive_ranges(),
+            k_ranges=k_ranges.to_naive_ranges(),
+            is_causal_mapping=[attn_type == 1 for attn_type in attn_type_map],
+            total_seqlen_q=total_seqlen_q,
+            total_seqlen_k=total_seqlen_k,
+        )
+
+        # -----   ref1. torch ref with high precision (fp32)   ---- #
+
+        total_q.grad, total_k.grad, total_v.grad = None, None, None
+
+        total_out_ref_high_precision = torch_attn_ref(
+            q=total_q,
+            k=total_k,
+            v=total_v,
+            mask=mask,
+            layout="thd",
+            high_precision=True,
+        )
+        total_out_ref_high_precision.backward(grad_total_out)
+        (
+            grad_total_q_ref_high_precision,
+            grad_total_k_ref_high_precision,
+            grad_total_v_ref_high_precision,
+        ) = (
+            total_q.grad,
+            total_k.grad,
+            total_v.grad,
+        )
+
+        # -----   ref2. torch ref with low precision (fp16/bf16)   ---- #
+
+        total_q.grad, total_k.grad, total_v.grad = None, None, None
+
+        total_out_ref_low_precision = torch_attn_ref(
+            q=total_q,
+            k=total_k,
+            v=total_v,
+            mask=mask,
+            layout="thd",
+            high_precision=False,
+        )
+        total_out_ref_low_precision.backward(grad_total_out)
+        (
+            grad_total_q_ref_low_precision,
+            grad_total_k_ref_low_precision,
+            grad_total_v_ref_low_precision,
+        ) = (
+            total_q.grad,
+            total_k.grad,
+            total_v.grad,
+        )
+
+        # -----   assert close for fwd out   ---- #
+
+        # fa style with Linf norm
+        out_norm = calc_inf_norm(total_out, total_out_ref_high_precision)
+        out_ref_norm = calc_inf_norm(
+            total_out_ref_low_precision, total_out_ref_high_precision
+        )
+        self.assertLessEqual(
+            out_norm,
+            norm_rtol_ratio * out_ref_norm,
+            msg=f"For {test_case=}: {out_norm=} should be no greater than {norm_rtol_ratio}x of {out_ref_norm=}",
+        )
+
+        # torch style with atol + rtol + mismatch threshold
+        o_thres = self._extract_mismatch_threshold_ref(
+            actual=total_out_ref_low_precision,
+            expected=total_out_ref_high_precision,
+            atol=o_atol,
+            rtol=o_rtol,
+            mismatch_thres_ratio=mismatch_thres_ratio,
+        )
+        magi_attention.testing.assert_close(
+            total_out,
+            total_out_ref_high_precision,
+            atol=o_atol,
+            rtol=o_rtol,
+            mismatch_threshold=o_thres,
+            test_case=f"{test_case} => o",
+        )
+
+        # -----   assert close for bwd dq   ---- #
+
+        # fa style with Linf norm
+        dq_norm = calc_inf_norm(grad_total_q, grad_total_q_ref_high_precision)
+        dq_ref_norm = calc_inf_norm(
+            grad_total_q_ref_low_precision, grad_total_q_ref_high_precision
+        )
+        self.assertLessEqual(
+            dq_norm,
+            norm_rtol_ratio * dq_ref_norm,
+            msg=f"For {test_case=}: {dq_norm=} should be no greater than {norm_rtol_ratio}x of {dq_ref_norm=}",
+        )
+
+        # torch style with atol + rtol + mismatch threshold
+        dq_thres = self._extract_mismatch_threshold_ref(
+            actual=grad_total_q_ref_low_precision,
+            expected=grad_total_q_ref_high_precision,
+            atol=dq_atol,
+            rtol=dq_rtol,
+            mismatch_thres_ratio=mismatch_thres_ratio,
+        )
+        magi_attention.testing.assert_close(
+            grad_total_q,
+            grad_total_q_ref_high_precision,
+            atol=dq_atol,
+            rtol=dq_rtol,
+            mismatch_threshold=dq_thres,
+            test_case=f"{test_case} => dq",
+        )
+
+        # -----   assert close for bwd dk   ---- #
+
+        # fa style with Linf norm
+        dk_norm = calc_inf_norm(grad_total_k, grad_total_k_ref_high_precision)
+        dk_ref_norm = calc_inf_norm(
+            grad_total_k_ref_low_precision, grad_total_k_ref_high_precision
+        )
+        self.assertLessEqual(
+            dk_norm,
+            norm_rtol_ratio * dk_ref_norm,
+            msg=f"For {test_case=}: {dk_norm=} should be no greater than {norm_rtol_ratio}x of {dk_ref_norm=}",
+        )
+
+        # torch style with atol + rtol + mismatch threshold
+        dk_thres = self._extract_mismatch_threshold_ref(
+            actual=grad_total_k_ref_low_precision,
+            expected=grad_total_k_ref_high_precision,
+            atol=dk_atol,
+            rtol=dk_rtol,
+            mismatch_thres_ratio=mismatch_thres_ratio,
+        )
+        magi_attention.testing.assert_close(
+            grad_total_k,
+            grad_total_k_ref_high_precision,
+            atol=dk_atol,
+            rtol=dk_rtol,
+            mismatch_threshold=dk_thres,
+            test_case=f"{test_case} => dk",
+        )
+
+        # -----   assert close for bwd dv   ---- #
+
+        # fa style with Linf norm
+        dv_norm = calc_inf_norm(grad_total_v, grad_total_v_ref_high_precision)
+        dv_ref_norm = calc_inf_norm(
+            grad_total_v_ref_low_precision, grad_total_v_ref_high_precision
+        )
+        self.assertLessEqual(
+            dv_norm,
+            norm_rtol_ratio * dv_ref_norm,
+            msg=f"For {test_case=}: {dv_norm=} should be no greater than {norm_rtol_ratio}x of {dv_ref_norm=}",
+        )
+
+        # torch style with atol + rtol + mismatch threshold
+        dv_thres = self._extract_mismatch_threshold_ref(
+            actual=grad_total_v_ref_low_precision,
+            expected=grad_total_v_ref_high_precision,
+            atol=dv_atol,
+            rtol=dv_rtol,
+            mismatch_thres_ratio=mismatch_thres_ratio,
+        )
+        magi_attention.testing.assert_close(
+            grad_total_v,
+            grad_total_v_ref_high_precision,
+            atol=dv_atol,
+            rtol=dv_rtol,
+            mismatch_threshold=dv_thres,
+            test_case=f"{test_case} => dv",
+        )
+
+    def _extract_mismatch_threshold_ref(
+        self,
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        atol: float,
+        rtol: float,
+        mismatch_thres_ratio: float = 1.0,
+    ) -> float:
+        mismatch_threshold_ref = 0.0
+        try:
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        except AssertionError as e:
+            error_msg = str(e)
+            _, _, mismatch_threshold_ref = extract_mismatch_info(error_msg)
+
+        return min(max(mismatch_threshold_ref * mismatch_thres_ratio, 0.0), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -132,16 +132,22 @@ class TestFlexFlashAttn(TestCase):
 
         # construct data
         q = torch.randn(
-            (seqlen, num_heads_q, head_dim), dtype=dtype, device=self.device,
-            requires_grad = True,
+            (seqlen, num_heads_q, head_dim),
+            dtype=dtype,
+            device=self.device,
+            requires_grad=True,
         )
         k = torch.randn(
-            (seqlen, num_heads_kv, head_dim), dtype=dtype, device=self.device,
-            requires_grad = True,
+            (seqlen, num_heads_kv, head_dim),
+            dtype=dtype,
+            device=self.device,
+            requires_grad=True,
         )
         v = torch.randn(
-            (seqlen, num_heads_kv, head_dim), dtype=dtype, device=self.device,
-            requires_grad = True,
+            (seqlen, num_heads_kv, head_dim),
+            dtype=dtype,
+            device=self.device,
+            requires_grad=True,
         )
         do = torch.randn_like(q)
 


### PR DESCRIPTION
- shifted the batch size to the x-dimension of backward gridDims, since the z-dimension must be less than 65536, thus once the batch size is too large (>= 65536), the z-dimension may overflow, causing an implicit kernel-launch error (*What's worse, this error may not be explicitly raised, resulting in the kernel being skipped*).

- added the unitest for ffa.

- fixed the static version bug in `setup.py` by introducing `versiongit` in `requirements.txt`.