### PR TITLE
Pull Request: Fix Memory Access Out-of-Bounds Issue in tile_idx_to_work_tile

### DIFF
--- a/magi_attention/csrc/flexible_flash_attention/tile_scheduler.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/tile_scheduler.hpp
@@ -468,7 +468,7 @@ public:
                     int next_cu_seqlen = __shfl_down_sync(0xffffffff, cur_cu_seqlen, 1);
                     seqlen = next_cu_seqlen - cur_cu_seqlen;
                 } else if (params.q_ranges) {
-                    seqlen = batch_idx <= params.num_batch ? params.q_ranges[2 * batch_idx + 1] - params.q_ranges[2 * batch_idx] : 0;
+                    seqlen = batch_idx < params.num_batch ? params.q_ranges[2 * batch_idx + 1] - params.q_ranges[2 * batch_idx] : 0;
                 } else {
                     seqlen = params.seqlen;
                 }


### PR DESCRIPTION
This pull request addresses a critical memory access out-of-bounds issue in the tile_idx_to_work_tile function. The problem was causing unexpected behavior and potential crashes in the application, especially when dealing with large batch or complex tile configurations.