### PR TITLE
Fix copyright

### DIFF
--- a/magi_attention/csrc/common/cuda_check.h
+++ b/magi_attention/csrc/common/cuda_check.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/common/static_switch.h
+++ b/magi_attention/csrc/common/static_switch.h
@@ -1,16 +1,18 @@
-// Copyright (c) 2025 SandAI. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 // Inspired by
 // https://github.com/NVIDIA/DALI/blob/main/include/dali/core/static_switch.h

--- a/magi_attention/csrc/common/utils.h
+++ b/magi_attention/csrc/common/utils.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/block.h
+++ b/magi_attention/csrc/flexible_flash_attention/block.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/copy_sm90_bulk_reduce.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/copy_sm90_bulk_reduce.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/epilogue_bwd.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/epilogue_bwd.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/epilogue_fwd.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/epilogue_fwd.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/fast_zero_fill.cu
+++ b/magi_attention/csrc/flexible_flash_attention/fast_zero_fill.cu
@@ -1,16 +1,18 @@
-// Copyright (c) 2025 SandAI. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 #include "fast_zero_fill_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/fast_zero_fill_kernel.h
+++ b/magi_attention/csrc/flexible_flash_attention/fast_zero_fill_kernel.h
@@ -1,16 +1,18 @@
-// Copyright (c) 2025 SandAI. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 #pragma once
 

--- a/magi_attention/csrc/flexible_flash_attention/fast_zero_fill_launch_template.h
+++ b/magi_attention/csrc/flexible_flash_attention/fast_zero_fill_launch_template.h
@@ -1,16 +1,18 @@
-// Copyright (c) 2025 SandAI. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 #pragma once
 

--- a/magi_attention/csrc/flexible_flash_attention/flash.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2023, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/flash_api.cpp
+++ b/magi_attention/csrc/flexible_flash_attention/flash_api.cpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,
  *Pradeep Ramani, Tri Dao.

--- a/magi_attention/csrc/flexible_flash_attention/flash_api.cpp
+++ b/magi_attention/csrc/flexible_flash_attention/flash_api.cpp
@@ -15,8 +15,7 @@
  *********************************************************************************/
 
 /******************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,
- *Pradeep Ramani, Tri Dao.
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/
 
 // Include these 2 headers instead of torch/extension.h since we don't need all

--- a/magi_attention/csrc/flexible_flash_attention/flash_bwd_kernel_sm90.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_bwd_kernel_sm90.h
@@ -15,8 +15,7 @@
  *********************************************************************************/
 
 /******************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,
- *Pradeep Ramani, Tri Dao.
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/
 
 #pragma once

--- a/magi_attention/csrc/flexible_flash_attention/flash_bwd_kernel_sm90.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_bwd_kernel_sm90.h
@@ -1,3 +1,18 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,

--- a/magi_attention/csrc/flexible_flash_attention/flash_bwd_launch_template.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_bwd_launch_template.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/flash_bwd_preprocess_kernel.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_bwd_preprocess_kernel.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
@@ -15,8 +15,7 @@
  *********************************************************************************/
 
 /******************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,
- *Pradeep Ramani, Tri Dao.
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/
 
 #pragma once

--- a/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar,
  *Pradeep Ramani, Tri Dao.

--- a/magi_attention/csrc/flexible_flash_attention/flash_fwd_launch_template.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_fwd_launch_template.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/generate_kernels.py
+++ b/magi_attention/csrc/flexible_flash_attention/generate_kernels.py
@@ -216,9 +216,12 @@ def batch_bwd(kernels_all) -> Generator[KERNEL_BATCH, None, None]:
 
 
 def write_kernel(kernel: Kernel | KERNEL_BATCH, autogen_dir: Path) -> None:
-    prelude = """// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"\n
+    prelude = """/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/\n
 """
     (autogen_dir / kernel.filename).write_text(prelude + kernel.template)
 

--- a/magi_attention/csrc/flexible_flash_attention/generate_kernels.py
+++ b/magi_attention/csrc/flexible_flash_attention/generate_kernels.py
@@ -216,14 +216,7 @@ def batch_bwd(kernels_all) -> Generator[KERNEL_BATCH, None, None]:
 
 
 def write_kernel(kernel: Kernel | KERNEL_BATCH, autogen_dir: Path) -> None:
-    prelude = """/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/\n
-"""
-    (autogen_dir / kernel.filename).write_text(prelude + kernel.template)
+    (autogen_dir / kernel.filename).write_text(kernel.template)
 
 
 def main(output_dir: Optional[str]) -> None:

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim128_bf16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_bf16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim128_fp16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim128_fp16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim192_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_bf16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim192_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim192_bf16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim192_bf16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim192_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim192_fp16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim192_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim192_fp16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim192_fp16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim64_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim64_bf16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_bf16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim64_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim64_bf16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim64_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdim64_fp16_softcapall_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim64_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim64_fp16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim64_fp16_fp16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_bf16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_bf16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_bf16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_bf16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim128_bf16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_fp16_bf16_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_sm90.cu"
 #include "flash_bwd_hdim128_fp16_fp16_disable_bwd_dkv_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu"
 #include "flash_bwd_hdim128_fp16_fp16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_bwd_hdim128_fp16_bf16_softcap_disable_bwd_dkv_atomic_reduction_sm90.cu"
 #include "flash_bwd_hdim128_fp16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_bwd_hdimall_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM128

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim128_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM192

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim192_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_bf16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_disable_fwd_atomic_reduction_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_launch_template.h"
 
 #ifndef FLASHATTENTION_DISABLE_HDIM64

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdim64_fp16_fp32_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_launch_template.h"
 

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_bf16_bf16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_hdim128_bf16_bf16_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_bf16_bf16_sm90.cu"
 #include "flash_fwd_hdim128_bf16_fp16_disable_fwd_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu"
 #include "flash_fwd_hdim128_bf16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_hdim128_bf16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_bf16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_fp16_bf16_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_hdim128_fp16_bf16_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_fp16_bf16_sm90.cu"
 #include "flash_fwd_hdim128_fp16_fp16_disable_fwd_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  *********************************************************************************/
 
-/**********************************************************************************
- * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
- * Splitting the different template instantiations to different files to speed up compilation.
- * This file is auto-generated. See "generate_kernels.py"
- * you may not use this file except in compliance with the License.
- *********************************************************************************/
-
 #include "flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu"
 #include "flash_fwd_hdim128_fp16_fp16_softcap_disable_fwd_atomic_reduction_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 // Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"

--- a/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
+++ b/magi_attention/csrc/flexible_flash_attention/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
@@ -14,9 +14,12 @@
  * limitations under the License.
  *********************************************************************************/
 
-// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-// Splitting the different template instantiations to different files to speed up compilation.
-// This file is auto-generated. See "generate_kernels.py"
+/**********************************************************************************
+ * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+ * Splitting the different template instantiations to different files to speed up compilation.
+ * This file is auto-generated. See "generate_kernels.py"
+ * you may not use this file except in compliance with the License.
+ *********************************************************************************/
 
 #include "flash_fwd_hdim128_fp16_bf16_softcap_disable_fwd_atomic_reduction_sm90.cu"
 #include "flash_fwd_hdim128_fp16_bf16_softcap_sm90.cu"

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/mask.h
+++ b/magi_attention/csrc/flexible_flash_attention/mask.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/named_barrier.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/named_barrier.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/seqlen.h
+++ b/magi_attention/csrc/flexible_flash_attention/seqlen.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/sm90_pipeline_no_cluster.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/sm90_pipeline_no_cluster.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/softmax.h
+++ b/magi_attention/csrc/flexible_flash_attention/softmax.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/tile_scheduler.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/tile_scheduler.hpp
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/tile_size.h
+++ b/magi_attention/csrc/flexible_flash_attention/tile_size.h
@@ -1,3 +1,19 @@
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
 /******************************************************************************
  * Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
  ******************************************************************************/

--- a/magi_attention/csrc/flexible_flash_attention/unique_consecutive_pairs.cu
+++ b/magi_attention/csrc/flexible_flash_attention/unique_consecutive_pairs.cu
@@ -1,16 +1,18 @@
-// Copyright (c) 2025 SandAI. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**********************************************************************************
+ * Copyright (c) 2025 SandAI. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
 
 #include <cuda_runtime.h>
 #include <torch/extension.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.versioningit]
 vcs = "git"
-default-version = "1.0.2"
+default-version = "1.0.3"
 
 [tool.versioningit.write]
 file = "magi_attention/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "A Distributed Attention Towards Linear Scalability for Ultra-Long Context, Heterogeneous Data Training"
 authors = [
   {name = "littsk", email = "zeweitao@sand.ai"},
-  {name = "Strivin0311", email = "hyp@smail.nju.edu.cn"}
+  {name = "Strivin0311", email = "yunpenghuang@sand.ai"},
 ]
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "A Distributed Attention Towards Linear Scalability for Ultra-Long Context, Heterogeneous Data Training"
 authors = [
   {name = "littsk", email = "zeweitao@sand.ai"},
-  {name = "Strivin", email = "hyp@smail.nju.edu.cn"}
+  {name = "Strivin0311", email = "hyp@smail.nju.edu.cn"}
 ]
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/tools/codestyle/copyright.py
+++ b/tools/codestyle/copyright.py
@@ -21,6 +21,10 @@ import os
 import re
 import sys
 
+# global current year
+NOW = int(os.getenv("MAGI_ATTENTION_COPYRIGHT_TEST_YEAR", datetime.datetime.now().year))
+
+# initial copyright for starting year 2025
 COPYRIGHT = """Copyright (c) 2025 SandAI. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,11 +40,29 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 
 RE_ENCODE = re.compile(r"^[ \t\v]*#.*?coding[:=]", re.IGNORECASE)
-RE_COPYRIGHT = re.compile(r".*Copyright \(c\) 2025 SandAI", re.IGNORECASE)
+RE_COPYRIGHT = re.compile(
+    r".*Copyright \(c\) (\d{4})(?:-(\d{4}))? SandAI", re.IGNORECASE
+)
 RE_SHEBANG = re.compile(r"^[ \t\v]*#[ \t]?\!")
 
 
-def _generate_copyright(comment_mark):
+def _is_python_file(path) -> bool:
+    lang_type = re.compile(r"\.(py|sh)$")
+    if lang_type.search(path) is not None:
+        return True
+    return False
+
+
+def _is_c_file(path) -> bool:
+    lang_type = re.compile(r"\.(h|c|hpp|cc|cpp|cu|go|cuh|proto)$")
+    if lang_type.search(path) is not None:
+        return True
+    return False
+
+
+def _generate_copyright(path, comment_mark) -> list[str]:
+    is_c_file = _is_c_file(path)
+
     if isinstance(comment_mark, tuple):
         start_mark, end_mark = comment_mark
     else:
@@ -48,60 +70,65 @@ def _generate_copyright(comment_mark):
         end_mark = comment_mark
 
     copyright = COPYRIGHT.split(os.linesep)
-    header = copyright[0].rstrip()
-
-    p = re.search("(\d{4})", header).group(0)  # noqa: W605
-    now = datetime.datetime.now()
-
-    header = header.replace(p, str(now.year))
+    if NOW == 2025:
+        header = "Copyright (c) 2025 SandAI. All Rights Reserved."
+    else:
+        header = f"Copyright (c) 2025-{NOW} SandAI. All Rights Reserved."
 
     ans = [
         start_mark
-        + "/**********************************************************************************"
+        + (
+            "/**********************************************************************************"
+            if is_c_file
+            else " "
+        )
         + os.linesep
     ]
-    ans.append(start_mark + " * " + header + os.linesep)
+    ans.append(start_mark + (" * " if is_c_file else " ") + header + os.linesep)
     for idx, line in enumerate(copyright[1:]):
-        if start_mark == "/*":
-            ans.append(" * " + line.rstrip() + os.linesep)
+        if start_mark == "#":
+            ans.append(comment_mark + " " + line.rstrip() + os.linesep)
         else:
             ans.append(start_mark + " * " + line.rstrip() + os.linesep)
     ans.append(
         start_mark
-        + " *********************************************************************************/"
+        + (
+            " *********************************************************************************/"
+            if is_c_file
+            else " "
+        )
         + os.linesep
     )
-    if end_mark:
+    if end_mark != "#":
         ans.append(end_mark + os.linesep)
 
     return ans
 
 
-def _get_comment_mark(path):
-    lang_type = re.compile(r"\.(py|sh)$")
-    if lang_type.search(path) is not None:
+def _get_comment_mark(path) -> str | tuple[str, str]:
+    if _is_python_file(path):
         return "#"
-
-    lang_type = re.compile(r"\.(h|c|hpp|cc|cpp|cu|go|cuh|proto)$")
-    if lang_type.search(path) is not None:
+    elif _is_c_file(path):
         return "", ""
-
-    return None
+    else:
+        raise RuntimeError(f"Unsupported file: {path}")
 
 
 def _check_copyright(path):
-    head = []
     try:
         with open(path) as f:
-            head = [next(f) for x in range(4)]
-    except StopIteration:
-        pass
-
-    for idx, line in enumerate(head):
-        if RE_COPYRIGHT.search(line) is not None:
-            return True
-
-    return False
+            for line in f:
+                match = RE_COPYRIGHT.search(line)
+                if match:
+                    year_str = match.group(1)
+                    if NOW == 2025:
+                        return 1 if year_str == "2025" else 2
+                    else:
+                        expected = f"2025-{NOW}"
+                        return 1 if year_str == expected else 2
+            return 0
+    except Exception:
+        return 0
 
 
 def generate_copyright(path, comment_mark):
@@ -113,7 +140,7 @@ def generate_copyright(path, comment_mark):
         if RE_ENCODE.search(line) or RE_SHEBANG.search(line):
             insert_line_no = i + 1
 
-    copyright = _generate_copyright(comment_mark)
+    copyright = _generate_copyright(path, comment_mark)
     if insert_line_no == 0:
         new_contents = copyright
         if len(original_contents) > 0 and len(original_contents[0].strip()) != 0:
@@ -135,6 +162,34 @@ def generate_copyright(path, comment_mark):
         output_file.write(new_contents)
 
 
+def update_copyright_year_in_file(path):
+    try:
+        with open(path, "r") as f:
+            lines = f.readlines()
+    except Exception:
+        return
+
+    new_lines = []
+    updated = False
+    for line in lines:
+        if not updated:
+            match = RE_COPYRIGHT.search(line)
+            if match:
+                if NOW == 2025:
+                    new_year = "2025"
+                else:
+                    new_year = f"2025-{NOW}"
+                new_line = re.sub(r"\d{4}(-\d{4})?", new_year, line, count=1)
+                new_lines.append(new_line)
+                updated = True
+                continue
+        new_lines.append(line)
+
+    if updated:
+        with open(path, "w") as f:
+            f.writelines(new_lines)
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Checker for copyright declaration.")
     parser.add_argument("filenames", nargs="*", help="Filenames to check")
@@ -146,10 +201,11 @@ def main(argv=None):
             print("warning:Unsupported file", path, file=sys.stderr)
             continue
 
-        if _check_copyright(path):
-            continue
-
-        generate_copyright(path, comment_mark)
+        status = _check_copyright(path)
+        if status == 0:
+            generate_copyright(path, comment_mark)
+        elif status == 2:
+            update_copyright_year_in_file(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- added copyright to missing-copyright files.
- fixed old cpp copyright format.
- fixed fa3 old copyright.
- fixed the instantiations copyright.
- updated copyright to support dynamic year, where the current year can be set by setting the environment variable, for example, `export MAGI_ATTENTION_COPYRIGHT_TEST_YEAR=2027` for testing.
- updated the default version from 1.0.0 to 1.0.3.