### PR TITLE
add cache to speedup solver

### DIFF
--- a/magi_attention/api/magi_attn_interface.py
+++ b/magi_attention/api/magi_attn_interface.py
@@ -387,7 +387,7 @@ def magi_attn_flex_key(
     key = DistAttnRuntimeKey(
         q_ranges=q_ranges,
         k_ranges=k_ranges,
-        attn_mask_type=attn_mask_type,
+        attn_mask_type=tuple(attn_mask_type),
         total_seqlen_q=total_seqlen_q,
         total_seqlen_k=total_seqlen_k,
         pad_size=pad_size,
@@ -395,6 +395,8 @@ def magi_attn_flex_key(
         cp_group=cp_group,
         cp_mesh=cp_mesh,
         dist_attn_config=dist_attn_config,
+        is_deterministic_mode_enable=magi_attention.is_deterministic_mode_enable(),
+        is_hierarchical_comm_enable=magi_attention.comm.is_hierarchical_comm_enable(),
     )
 
     # Validate sequence length

--- a/magi_attention/dist_attn_runtime_mgr.py
+++ b/magi_attention/dist_attn_runtime_mgr.py
@@ -39,7 +39,7 @@ from magi_attention.utils import is_list_value_all, is_same_process_group, wrap_
 class DistAttnRuntimeKey:
     q_ranges: AttnRanges
     k_ranges: AttnRanges
-    attn_mask_type: list[AttnMaskType]
+    attn_mask_type: tuple[AttnMaskType, ...]
     total_seqlen_q: int
     total_seqlen_k: int
     pad_size: int
@@ -47,10 +47,8 @@ class DistAttnRuntimeKey:
     cp_group: dist.ProcessGroup
     cp_mesh: DeviceMesh | None
     dist_attn_config: DistAttnConfig
-
-    def __post_init__(self):
-        # make attn_mask_type a tuple to be hashable
-        object.__setattr__(self, "attn_mask_type", tuple(self.attn_mask_type))
+    is_deterministic_mode_enable: bool
+    is_hierarchical_comm_enable: bool
 
 
 class DistAttnRuntimeMgr:


### PR DESCRIPTION
- add (lru) cache to `make_ranges_local` and `find_overlap_ranges` for `AttnRanges` to spend up `DistAttnSolver`.
- add `is_deterministic_mode_enable` and `is_hierarchical_comm_enable` to `DistAttnRuntimeKey` since these flags would affect the runtime mgr status.