### PR TITLE
Support torch compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ For more usage instructions, you can refer to `magi_attention/functional/flex_fl
   # --- Distributed attention computation --- #
 
   local_out, _ = calc_attn( # the second return value is `local_lse` (log-sum-exp), known as the online-softmax correction factor
-    q=local_q,
-    k=local_k,
-    v=local_v,
-    key=magi_attn_runtime_key,
+      q=local_q,
+      k=local_k,
+      v=local_v,
+      key=magi_attn_runtime_key,
   )
 
   # --- Undispatch the output tensor along seqlen dim from multiple ranks and unpad --- #
@@ -298,8 +298,8 @@ For more usage instructions, you can refer to `magi_attention/functional/flex_fl
   # NOTE: the undispatch API may not be used until the moment you need the seqlen dimension to be compelete and ordered,
   # e.g. for either aforementioned sample-wise operations, or loss computation
   total_out = undispatch(
-    x=local_out,
-    key=magi_attn_runtime_key,
+      x=local_out,
+      key=magi_attn_runtime_key,
   )
 
   # --- Clear up distributed environment --- #

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ For more usage instructions, you can refer to `magi_attention/functional/flex_fl
   attn_mask_type = [AttnMaskType.FULL] * len(q_ranges)
   total_seqlen_q = total_seqlen_k = total_seqlen
   pad_size = compute_pad_size( # pad embeds along seqlen dim for better performance
-    total_seqlen_q=total_seqlen_q,
-    cp_size=world_size, # assuming we only have 1-dim context parallelism (cp)
-    chunk_size=chunk_size,
+      total_seqlen_q=total_seqlen_q,
+      cp_size=world_size, # assuming we only have 1-dim context parallelism (cp)
+      chunk_size=chunk_size,
   )
 
   # --- Dispatch token embedding tensor along seqlen dim to multiple ranks --- #

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -134,9 +134,9 @@ k_ranges = AttnRanges.from_ranges(
 attn_mask_type = [AttnMaskType.FULL] * len(q_ranges)
 total_seqlen_q = total_seqlen_k = total_seqlen
 pad_size = compute_pad_size( # pad embeds along seqlen dim for better performance
-total_seqlen_q=total_seqlen_q,
-cp_size=world_size, # assuming we only have 1-dim context parallelism (cp)
-chunk_size=chunk_size,
+    total_seqlen_q=total_seqlen_q,
+    cp_size=world_size, # assuming we only have 1-dim context parallelism (cp)
+    chunk_size=chunk_size,
 )
 
 # --- Dispatch token embedding tensor along seqlen dim to multiple ranks --- #

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -172,10 +172,10 @@ local_v = v_proj(local_x).view(-1, num_heads_kv, head_dim)
 # --- Distributed attention computation --- #
 
 local_out, _ = calc_attn( # the second return value is `local_lse` (log-sum-exp), known as the online-softmax correction factor
-q=local_q,
-k=local_k,
-v=local_v,
-key=magi_attn_runtime_key,
+    q=local_q,
+    k=local_k,
+    v=local_v,
+    key=magi_attn_runtime_key,
 )
 
 # --- Undispatch the output tensor along seqlen dim from multiple ranks and unpad --- #
@@ -183,8 +183,8 @@ key=magi_attn_runtime_key,
 # NOTE: the undispatch API may not be used until the moment you need the seqlen dimension to be compelete and ordered,
 # e.g. for either aforementioned sample-wise operations, or loss computation
 total_out = undispatch(
-x=local_out,
-key=magi_attn_runtime_key,
+    x=local_out,
+    key=magi_attn_runtime_key,
 )
 
 # --- Clear up distributed environment --- #

--- a/magi_attention/api/magi_attn_interface.py
+++ b/magi_attention/api/magi_attn_interface.py
@@ -39,7 +39,7 @@ from .functools import apply_padding, pad_at_dim, unpad_at_dim
 
 dist_attn_runtime_dict = DistAttnRuntimeDict(
     max_size=magi_attention.dist_attn_runtime_dict_size()
-)  # [DistAttnRuntimeKey, DistAttnRuntimeMgr]
+)  # dict[DistAttnRuntimeKey, DistAttnRuntimeMgr]
 
 
 GeneralAttnMaskType: TypeAlias = str | AttnMaskType | Sequence[str | AttnMaskType]

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -301,7 +301,7 @@ class DistFlashAttnRuntime:
                     f"attn-fwd: area={attn_arg.total_area} | "
                     f"qr={attn_arg.q_ranges} | kr={attn_arg.k_ranges}"
                 ):
-                    out, lse, *rest = _flex_flash_attn_forward(
+                    out, lse = _flex_flash_attn_forward(
                         q=q,
                         k=k,
                         v=v,
@@ -390,7 +390,7 @@ class DistFlashAttnRuntime:
                     k=k,
                     v=v,
                     out=o,
-                    softmax_lse=lse,
+                    lse=lse,
                     dq=dq_acc,  # directly reduce to dq_acc
                     dk=partial_dk,
                     dv=partial_dv,

--- a/magi_attention/functional/flex_flash_attn.py
+++ b/magi_attention/functional/flex_flash_attn.py
@@ -268,7 +268,7 @@ def _flex_flash_attn_forward(
     sm_margin: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if torch.compiler.is_compiling():
-        out = out or torch.zeros_like(
+        out = out or torch.empty_like(
             q, dtype=out_type or torch.float32, device=q.device
         )
         lse = lse or torch.full(

--- a/magi_attention/utils/nvtx.py
+++ b/magi_attention/utils/nvtx.py
@@ -55,7 +55,7 @@ class add_nvtx_event:
     Context manager to add an NVTX event around a code block.
 
     Args:
-        event_name: The name of the event to be recorded.
+        event_name (str): The name of the event to be recorded.
     """
 
     def __init__(self, event_name: str):
@@ -83,10 +83,10 @@ def instrument_nvtx(func: F) -> F:
     Decorator that records an NVTX range for the duration of the function call.
 
     Args:
-    - func: The function to be decorated.
+        func (Callable): The function to be decorated.
 
     Returns:
-    - Wrapped function that is now being profiled.
+        Callable: The wrapped function that is now being profiled.
     """
 
     @wraps(func)
@@ -119,11 +119,11 @@ def switch_profile(
     at the start iteration and turns it off at the end iteration.
 
     Args:
-        iter_id: The current iteration number.
-        start: The iteration number to start profiling.
-        end: The iteration number to end profiling.
-        profile_ranks: List of ranks to be profiled.
-        event_name: Custom name for the profiling event. If None, defaults to 'iter{iter_id}'.
+        iter_id (int): The current iteration number.
+        start (int): The iteration number to start profiling.
+        end (int): The iteration number to end profiling.
+        profile_ranks (list[int]): List of ranks to be profiled.
+        event_name (str, optional): Custom name for the profiling event. If None, defaults to 'iter{iter_id}'.
     """
 
     if not torch.distributed.is_initialized():

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -524,6 +524,9 @@ class TestFlexFlashAttn(TestCase):
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
             attn_type_map=torch.tensor(attn_type_map, dtype=torch.int32, device="cuda"),
+            # FIXME: compiling does not support auto_range_merge
+            # due to custom unique_consecutive_pairs kernel with dynamic output shape
+            auto_range_merge=False,
         )
         o.backward(do)
         dq, dk, dv = q.grad, k.grad, v.grad

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -343,7 +343,7 @@ class TestFlexFlashAttn(TestCase):
     @parameterize("auto_range_merge", [False, True])
     @parameterize("deterministic", [False, True])
     @parameterize("test_accumulation_inplace", [False, True])
-    def test_flex_attn(
+    def test_flex_flash_attn(
         self,
         attn_mask_config: dict[str, Any],
         model_config: dict[str, Any],
@@ -494,6 +494,56 @@ class TestFlexFlashAttn(TestCase):
             dtype=dtype,
             test_case=test_case,
             err_msg_list=err_msg_list,
+        )
+
+    def test_compiled_flex_flash_attn(self):
+        s, h, d = 2048, 6, 128
+        hk = 3
+
+        q = torch.randn(s, h, d, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(s, hk, d, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn_like(k)
+        do = torch.randn_like(q)
+
+        [x.requires_grad_(True) for x in (q, k, v)]
+
+        q_ranges = AttnRanges.from_ranges([[0, s // 2], [s // 2, s]])
+        k_ranges = AttnRanges.from_ranges([[0, s // 2], [s // 2, s]])
+        attn_type_map = [0, 1]
+        max_seqlen_q = s // 2
+        max_seqlen_k = s // 2
+
+        compiled_ffa_func = torch.compile(fullgraph=True)(flex_flash_attn_func)
+
+        o, lse = compiled_ffa_func(
+            q=q,
+            k=k,
+            v=v,
+            q_ranges=q_ranges.to_tensor("cuda"),
+            k_ranges=k_ranges.to_tensor("cuda"),
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            attn_type_map=torch.tensor(attn_type_map, dtype=torch.int32, device="cuda"),
+        )
+        o.backward(do)
+        dq, dk, dv = q.grad, k.grad, v.grad
+
+        self.assert_close_to_torch_ref(
+            q_ranges=q_ranges,
+            k_ranges=k_ranges,
+            attn_type_map=attn_type_map,
+            total_seqlen_q=s,
+            total_seqlen_k=s,
+            total_q=q,
+            total_k=k,
+            total_v=v,
+            total_out=o,
+            grad_total_q=dq,
+            grad_total_k=dk,
+            grad_total_v=dv,
+            grad_total_out=do,
+            dtype=torch.bfloat16,
+            test_case="test_compiled_flex_flash_attn",
         )
 
     def check_deterministic(

--- a/tests/test_interface/test_magi_attn_interface.py
+++ b/tests/test_interface/test_magi_attn_interface.py
@@ -714,9 +714,7 @@ class TestInterfaceWithWorldSize8(TestInterfaceBaseWithWorldSize1):
     def test_compiled_magiattn(self):
         # --- Define attention config --- #
 
-        total_seqlen = (
-            32 * 1024
-        )  # 32k tokens, if we dispatch it to 8 GPUs, then each GPU holds 4k tokens
+        total_seqlen = 32 * 1024  # 32k tokens
         num_heads_q = 48  # number of attention (query) heads
         num_heads_kv = 8  # number of key/value heads (GQA)
         head_dim = 128  # dimension of each attention head

--- a/tests/test_interface/test_magi_attn_interface.py
+++ b/tests/test_interface/test_magi_attn_interface.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 import torch
 import torch.distributed as dist
+import torch.nn as nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests
@@ -29,10 +30,14 @@ from magi_attention.api.functools import (
     pad_at_dim,
 )
 from magi_attention.api.magi_attn_interface import (
+    calc_attn,
+    dispatch,
     dist_attn_runtime_dict,
     get_position_ids,
     magi_attn_flex_dispatch,
+    magi_attn_flex_key,
     magi_attn_varlen_dispatch,
+    undispatch,
 )
 from magi_attention.common.enum import AttnMaskType, AttnOverlapMode
 from magi_attention.common.ranges import AttnRanges
@@ -60,6 +65,7 @@ from magi_attention.testing.precision import (
     H100_NVLINK_A2A_BWU,
     H100_NVLINK_BANDWIDTH,
     H100_TFLOPS_16,
+    switch_deterministic_mode_decorator,
 )
 from magi_attention.utils import (
     get_a2a_corr_factor,
@@ -701,6 +707,143 @@ class TestInterfaceWithWorldSize8(TestInterfaceBaseWithWorldSize1):
     @skip_if_lt_x_gpu(8)
     def test_interface(self, *args, **kwargs):
         super().test_interface(*args, **kwargs)
+
+    @skip_if_lt_x_gpu(8)
+    @with_comms
+    @switch_deterministic_mode_decorator(enable=True)
+    def test_compiled_magiattn(self):
+        # --- Define attention config --- #
+
+        total_seqlen = (
+            32 * 1024
+        )  # 32k tokens, if we dispatch it to 8 GPUs, then each GPU holds 4k tokens
+        num_heads_q = 48  # number of attention (query) heads
+        num_heads_kv = 8  # number of key/value heads (GQA)
+        head_dim = 128  # dimension of each attention head
+        dtype = torch.bfloat16  # attention activation / computation dtype
+        chunk_size = 512  # chunk size
+        embed_dim = 4096  # token embedding tensor
+
+        # --- Initialize MagiAttention meta configs for customized attention mask --- #
+
+        q_ranges = AttnRanges.from_ranges(
+            [
+                [0, 4096],  # 0~4k
+                [4096, 8192],  # 4k~8k
+                [8192, 12288],  # 8k~12k
+                [12288, 16384],  # 12k~16k
+                [16384, 20480],  # 16k~20k
+                [20480, 24576],  # 20k~24k
+                [24576, 28672],  # 24k~28k
+                [28672, 32768],  # 28k~32k
+            ]
+        )
+        k_ranges = AttnRanges.from_ranges(
+            [
+                [0, 4096],  # 0~4k
+                [0, 8192],  # 0~8k
+                [0, 12288],  # 0~12k
+                [0, 16384],  # 0~16k
+                [0, 20480],  # 0~20k
+                [0, 24576],  # 0~24k
+                [0, 28672],  # 0~28k
+                [0, 32768],  # 0~32k
+            ]
+        )
+        attn_mask_type = [AttnMaskType.FULL] * len(q_ranges)
+        total_seqlen_q = total_seqlen_k = total_seqlen
+        pad_size = compute_pad_size(  # pad embeds along seqlen dim for better performance
+            total_seqlen_q=total_seqlen_q,
+            cp_size=self.world_size,  # assuming we only have 1-dim context parallelism (cp)
+            chunk_size=chunk_size,
+        )
+
+        global_dout = torch.randn(
+            total_seqlen, num_heads_q, head_dim, device=self.device, dtype=dtype
+        )
+        dist.all_reduce(global_dout, group=self.process_group)
+
+        q_proj = nn.Linear(
+            embed_dim, num_heads_q * head_dim, dtype=dtype, device=self.device
+        )
+        k_proj = nn.Linear(
+            embed_dim, num_heads_kv * head_dim, dtype=dtype, device=self.device
+        )
+        v_proj = nn.Linear(
+            embed_dim, num_heads_kv * head_dim, dtype=dtype, device=self.device
+        )
+
+        # --- Compute magi_attn runtime key --- #
+
+        magi_attn_runtime_key = magi_attn_flex_key(
+            q_ranges=q_ranges,
+            k_ranges=k_ranges,
+            attn_mask_type=attn_mask_type,
+            total_seqlen_q=total_seqlen_q,
+            total_seqlen_k=total_seqlen_k,
+            pad_size=pad_size,
+            chunk_size=chunk_size,
+            cp_group_or_mesh=self.process_group,  # assuming we only have 1-dim context parallelism (cp)
+        )
+
+        total_out_ref, dx_ref = None, None
+        for iter in range(6):
+            use_compiled_magiattn = iter % 2 == 1
+
+            torch.manual_seed(self.seed + iter // 2)
+            x = torch.randn(
+                total_seqlen,
+                embed_dim,
+                device=self.device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            dist.all_reduce(x.data, group=self.process_group)
+
+            # --- Dispatch and pad --- #
+
+            local_x = dispatch(x, key=magi_attn_runtime_key)
+
+            # --- Simulate QKV projection --- #
+
+            local_q = q_proj(local_x).view(-1, num_heads_q, head_dim)
+            local_k = k_proj(local_x).view(-1, num_heads_kv, head_dim)
+            local_v = v_proj(local_x).view(-1, num_heads_kv, head_dim)
+
+            # --- Apply compiled magi_attn func --- #
+
+            # NOTE: since torch.compile does not support async dist comm,
+            # we can not compile it with fullgraph=True
+            magiattn_func = (
+                torch.compile(fullgraph=False)(calc_attn)
+                if use_compiled_magiattn
+                else calc_attn
+            )
+            local_out, _ = magiattn_func(
+                q=local_q,
+                k=local_k,
+                v=local_v,
+                key=magi_attn_runtime_key,
+            )
+
+            # --- Undispatch and unpad --- #
+
+            total_out = undispatch(
+                x=local_out,
+                key=magi_attn_runtime_key,
+            )
+
+            total_out.backward(global_dout)
+
+            dx = x.grad
+
+            if use_compiled_magiattn:
+                assert total_out_ref is not None and dx_ref is not None
+                torch.testing.assert_close(total_out, total_out_ref)
+                torch.testing.assert_close(dx, dx_ref)
+            else:
+                total_out_ref = total_out.detach().clone()
+                dx_ref = dx.detach().clone()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- supported nvtx with torch.compile.
- supported ffa with torch.compile, with simple ut added to `test_flex_flash_attention`.
- supported magiattn with torch.compile, with simple ut added to `test_magi_attn_interface`.
- fixed wrong indentions in README and docs/quickstart.