### PR TITLE
[HotFix] Fix softmax_d compile bug

### DIFF
--- a/exps/dist_attn/baselines/usp_nsa.py
+++ b/exps/dist_attn/baselines/usp_nsa.py
@@ -367,7 +367,7 @@ class FFATopkAGAttnFunc(torch.autograd.Function):
             0,  # sm_margin
         ]
 
-        flatten_dq, flatten_dk, flatten_dv, _ = _flex_flash_attn_backward(
+        flatten_dq, flatten_dk, flatten_dv = _flex_flash_attn_backward(
             flatten_dout,
             flatten_q,
             flatten_k_ag,
@@ -510,7 +510,7 @@ class FFAWinAGAttnFunc(torch.autograd.Function):
             0,  # sm_margin
         ]
 
-        dq, dk, dv, _ = _flex_flash_attn_backward(
+        dq, dk, dv = _flex_flash_attn_backward(
             dout,
             q,
             k_ag,
@@ -718,7 +718,7 @@ class FFACmpAGAttnFunc(torch.autograd.Function):
             0,  # sm_margin
         ]
 
-        dq, dk, dv, _ = _flex_flash_attn_backward(
+        dq, dk, dv = _flex_flash_attn_backward(
             dout,
             q_cmp,
             k_ag_cmp,

--- a/magi_attention/csrc/flexible_flash_attention/bwd_inst_template.jinja
+++ b/magi_attention/csrc/flexible_flash_attention/bwd_inst_template.jinja
@@ -77,7 +77,7 @@ std::vector<at::Tensor> mha_bwd(
   _check_runtime_contract_bwd(q, dk_type_, dv_type_, softcap, disable_bwd_dkv_atomic_reduction);
 
   // Parameter preparation (including output tensor allocation)
-  auto [params, dq, dk, dv, softmax_d, softmax_lse_log2] = prepare_mha_bwd(
+  auto [params, dq, dk, dv] = prepare_mha_bwd(
       dout, q, k, v, out, dq_, dk_, dv_, softmax_lse, q_ranges, k_ranges,
       max_seqlen_q, max_seqlen_k, attn_type_map_, merge_k_ranges_, bwd_kq_map_,
       bwd_unique_count_, softmax_scale, softcap, disable_bwd_dkv_atomic_reduction,
@@ -88,7 +88,7 @@ std::vector<at::Tensor> mha_bwd(
   // Kernel launch (single variant)
   run_mha_bwd_<kArch, TCompute, TDkv, kHeadDim, kHasSoftcap, kDisableDkvAtomic>(params, stream);
 
-  return {dq, dk, dv, softmax_d, softmax_lse_log2};
+  return {dq, dk, dv};
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/magi_attention/csrc/flexible_flash_attention/flex_flash_bwd.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/flex_flash_bwd.hpp
@@ -246,5 +246,5 @@ std::tuple<Flash_bwd_params, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at:
       sm_margin,
       disable_bwd_dkv_atomic_reduction);
 
-  return {params, dq, dk, dv, softmax_d, softmax_lse_log2};
+  return {params, dq, dk, dv};
 }

--- a/magi_attention/csrc/flexible_flash_attention/flex_flash_bwd.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/flex_flash_bwd.hpp
@@ -80,7 +80,7 @@ struct type_caster<at::ScalarType> {
 //   });
 // }
 
-std::tuple<Flash_bwd_params, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> prepare_mha_bwd(
+std::tuple<Flash_bwd_params, at::Tensor, at::Tensor, at::Tensor> prepare_mha_bwd(
     const at::Tensor& dout,
     const at::Tensor& q,
     const at::Tensor& k,

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -462,7 +462,7 @@ class DistAttnRuntime:
                 # to reduce the error caused by the out correction
                 partial_dkv = torch.zeros_like(kv, dtype=torch.float32)
                 partial_dk, partial_dv = self.chunk_kv(partial_dkv)
-                partial_dq, partial_dk, partial_dv, *rest = _flex_flash_attn_backward(
+                partial_dq, partial_dk, partial_dv = _flex_flash_attn_backward(
                     dout=do,
                     q=q,
                     k=k,

--- a/tests/test_attn/test_block_sparse_attn.py
+++ b/tests/test_attn/test_block_sparse_attn.py
@@ -223,7 +223,7 @@ class TestBlockSparseAttn(DistTestBase):
         dk_acc = torch.randn_like(k, dtype=torch.float32)
         dv_acc = torch.randn_like(v, dtype=torch.float32)
 
-        dq_ref, dk_ref, dv_ref, _ = _flex_flash_attn_backward(
+        dq_ref, dk_ref, dv_ref = _flex_flash_attn_backward(
             do,
             q,
             k,
@@ -253,7 +253,7 @@ class TestBlockSparseAttn(DistTestBase):
         dq_ref += dq_acc
         dk_ref += dk_acc
         dv_ref += dv_acc
-        dq_acc, dk_acc, dv_acc, _ = _flex_flash_attn_backward(
+        dq_acc, dk_acc, dv_acc = _flex_flash_attn_backward(
             do,
             q,
             k,

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -354,7 +354,7 @@ class TestFlexFlashAttn(DistTestBase):
         dk_acc = torch.randn_like(k, dtype=torch.float32)
         dv_acc = torch.randn_like(v, dtype=torch.float32)
 
-        dq_ref, dk_ref, dv_ref, _ = _flex_flash_attn_backward(
+        dq_ref, dk_ref, dv_ref = _flex_flash_attn_backward(
             do,
             q,
             k,
@@ -386,7 +386,7 @@ class TestFlexFlashAttn(DistTestBase):
         dk_ref += dk_acc
         dv_ref += dv_acc
 
-        dq_acc, dk_acc, dv_acc, _ = _flex_flash_attn_backward(
+        dq_acc, dk_acc, dv_acc = _flex_flash_attn_backward(
             do,
             q,
             k,


### PR DESCRIPTION
- fixed `softmax_d` shape/stride mismatch bug with `torch.compile` by removing it from the  return values of ffa bwd kernel, according to the issue: https://github.com/SandAI-org/MagiAttention/issues/137
- fixed everywhere else calling `_flex_flash_attn_backward` for return values.