### PR TITLE
[HotFix] Fix the bug for negative expected head in intranode group reduce

### DIFF
--- a/magi_attention/csrc/comm/grpcoll/buffer.cpp
+++ b/magi_attention/csrc/comm/grpcoll/buffer.cpp
@@ -73,6 +73,8 @@ Buffer::Buffer(int rank, int num_ranks, int64_t num_nvl_bytes, int64_t num_rdma_
   int64_t barrier_signal_ptr_bytes = NUM_MAX_NVL_PEERS * sizeof(int*); // host signal ptr array to each signal for each nvl rank
 
   // Common checks
+  // FIXME: the upper limit of `INT_MAX` corresponds to the maximum buffer size of around 2GB
+  // which seems not enough in some rare cases, and requires to be scaled up
   GRPCOLL_HOST_ASSERT(num_nvl_bytes % NUM_BUFFER_ALIGNMENT_BYTES == 0 and (num_nvl_bytes <= INT_MAX or num_rdma_bytes == 0));
   GRPCOLL_HOST_ASSERT(num_rdma_bytes % NUM_BUFFER_ALIGNMENT_BYTES == 0 and (low_latency_mode or num_rdma_bytes <= INT_MAX));
   GRPCOLL_HOST_ASSERT(0 <= rank and rank < num_ranks and (num_ranks <= NUM_MAX_NVL_PEERS * NUM_MAX_RDMA_PEERS or low_latency_mode));


### PR DESCRIPTION
- fixed the bug for negative expected head in `intranode_group_reduce` kernel.
- added more detailed comments to explain the behavior of expected head and `cached_notify_group_reduce` kernel.
- added a `FIXME` for `INT_MAX` upper limit of `num_nvl_bytes` and `num_rdam_bytes`.
- removed the macro of `GRPCOLL_DEBUG` to always enable timeout check and print.