### PR TITLE
[WIP] Add block sparse examples

### DIFF
--- a/examples/sparse_attention/README.md
+++ b/examples/sparse_attention/README.md
@@ -1,0 +1,40 @@
+## Sparse Attention Toturials
+
+Usage Guide for MagiAttention in Sparse Attention Scenarios.
+For now, we only support uniform block sparse(q_block_size and k_block_size are the same for each block) and topk indices as input.
+
+### examples
+```python
+from magi_attention.functional import block_sparse_attn
+
+out, lse = block_sparse_attn(q, k, v, q_block_size, k_block_size, topk_indices)
+```
+
+### Tuning Guide
+
+
+| ref_block_size(q_block_size, k_block_size) | qhead_per_k_head | swapab | packgqa | sparse_load | tile_shape | tflops |
+|--------------------------------------------|------------------|-------|---------|-------------|------------|--------|
+| (1, 64)                                    | 8                | True  | True    | False       | (8, 64)    | 56     |
+| (8, 64)                                    | 8                | False | True    | False       | (64, 64)   | 355    |
+| (16, 64)                                   | 8                | False | True    | False       | (128, 64)  | 468    |
+| (64, 64)                                   | 8                | False | True    | False       | (128, 64)  | 480    |
+| (128, 128)                                 | 8                | False | False   | False       | (128, 128) | 585    |
+| (384, 384)                                 | 8                | False | False   | False       | (128, 128) | 633    |
+| (128, 1)                                   | 8                | False | False   | True        | (128, 128) | 388    |
+
+
+**Explanation:**
+
+- **swapab**: Enable swap_ab mode for optimizing performance when q_block_size is small (<= 16). Cannot be enabled together with sparse_load.
+
+- **packgqa**: Group query heads sharing the same KV head into a single computation block tile. Significantly improves computational efficiency when q_block_size is small. Recommended for GQA scenarios.
+
+- **sparse_load**: Enable sparse load mode for optimizing performance when k_block_size is small (<= 64). Must be used together with auto_range_merge=True. Cannot be enabled together with swapab.
+
+- **tile_shape**: Internal tile size configuration for FFA kernel (M, N). Automatically selected based on ref_block_size, or can be manually specified via sparse_args.
+
+
+
+### Blog
+TODO: add details of implementation and experiments.

--- a/examples/sparse_attention/block_sparse_attn.py
+++ b/examples/sparse_attention/block_sparse_attn.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2025-2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Simple example demonstrating block_sparse_attn usage with TFLOPS measurement.
+
+This script shows the minimal usage of block_sparse_attn interface and measures
+the performance in TFLOPS for forward pass only.
+"""
+
+import time
+
+import torch
+
+from magi_attention.functional import block_sparse_attn
+from magi_attention.utils.sparse_utils import generate_block_sparse_pattern
+
+
+def generate_data(
+    seqlen_q, seqlen_k, num_q_heads, num_kv_heads, head_dim, dtype, device
+):
+    """Generate random data for block sparse attention."""
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    q = torch.randn(seqlen_q, num_q_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(seqlen_k, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(seqlen_k, num_kv_heads, head_dim, dtype=dtype, device=device)
+
+    return q, k, v
+
+
+def generate_topk_indices(
+    seqlen_q,
+    seqlen_k,
+    num_q_heads,
+    num_kv_heads,
+    q_block_size,
+    k_block_size,
+    sparsity_ratio,
+    device,
+):
+    """Generate topk indices for block sparse attention."""
+    num_q_blocks = seqlen_q // q_block_size
+    num_kv_blocks = seqlen_k // k_block_size
+
+    topk_indices, _ = generate_block_sparse_pattern(
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        num_q_blocks=num_q_blocks,
+        num_kv_blocks=num_kv_blocks,
+        sparsity=sparsity_ratio,
+        mode="per_kv_head",
+        sparse_format="topk",
+        device=device,
+    )
+    # block_mask is topk_indices with shape [num_kv_heads, num_q_blocks, topk]
+    return topk_indices
+
+
+def test_block_sparse_attn_speed(
+    seqlen_q,
+    seqlen_k,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    q_block_size,
+    k_block_size,
+    sparsity_ratio,
+    dtype=torch.bfloat16,
+):
+    """Speed test for block_sparse_attn."""
+    device = torch.cuda.current_device()
+
+    # Generate data
+    q, k, v = generate_data(
+        seqlen_q, seqlen_k, num_q_heads, num_kv_heads, head_dim, dtype, device
+    )
+    topk_indices = generate_topk_indices(
+        seqlen_q,
+        seqlen_k,
+        num_q_heads,
+        num_kv_heads,
+        q_block_size,
+        k_block_size,
+        sparsity_ratio,
+        device,
+    )
+
+    warmup_iters = 10
+    perf_test_iters = 100
+
+    # Warmup
+    for _ in range(warmup_iters):
+        _ = block_sparse_attn(
+            q=q,
+            k=k,
+            v=v,
+            q_block_size=q_block_size,
+            k_block_size=k_block_size,
+            topk_indices=topk_indices,
+        )
+
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(perf_test_iters):
+        out, lse = block_sparse_attn(
+            q=q,
+            k=k,
+            v=v,
+            q_block_size=q_block_size,
+            k_block_size=k_block_size,
+            topk_indices=topk_indices,
+        )
+    torch.cuda.synchronize()
+    elapsed_time_ms = (time.perf_counter() - start) / perf_test_iters * 1000
+
+    # Calculate TFLOPS
+    attn_flops = 4 * seqlen_q * seqlen_k * num_q_heads * head_dim * sparsity_ratio
+    tflops = attn_flops / elapsed_time_ms * 1e-9
+
+    print(
+        f"\nseqlen_q:{seqlen_q} seqlen_k:{seqlen_k} "
+        f"num_q_heads:{num_q_heads} num_kv_heads:{num_kv_heads} "
+        f"head_dim:{head_dim} q_block_size:{q_block_size} k_block_size:{k_block_size} "
+        f"sparsity_ratio:{sparsity_ratio}"
+    )
+    print(f"Time: {elapsed_time_ms:.2f}ms, TFLOPS: {tflops:.2f}")
+
+
+if __name__ == "__main__":
+    seqlen_q = 48 * 1024
+    seqlen_k = 48 * 1024
+
+    # TODO: more format print.
+    print("Test block sparse attention with block (64, 64) and MHA setting.")
+    test_block_sparse_attn_speed(
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        num_q_heads=64,
+        num_kv_heads=64,
+        head_dim=128,
+        q_block_size=64,
+        k_block_size=64,
+        sparsity_ratio=0.1,
+    )
+
+    print("Test block sparse attention with block (1, 128) and GQA setting.")
+    test_block_sparse_attn_speed(
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        num_q_heads=64,
+        num_kv_heads=8,
+        head_dim=128,
+        q_block_size=1,
+        k_block_size=128,
+        sparsity_ratio=0.1,
+    )
+
+    print("Test block sparse attention with block (128, 1) and GQA setting.")
+    test_block_sparse_attn_speed(
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        num_q_heads=64,
+        num_kv_heads=8,
+        head_dim=128,
+        q_block_size=128,
+        k_block_size=1,
+        sparsity_ratio=0.1,
+    )

--- a/exps/attn/profile_ffa/ffa_benchmark.py
+++ b/exps/attn/profile_ffa/ffa_benchmark.py
@@ -38,9 +38,8 @@ from exps.attn.baselines.utils import (
 # -----------------------------------------------------------------------------
 from magi_attention.functional import flex_flash_attn_func as ffa_func
 from magi_attention.utils.sparse_utils import (
-    flatten_block_mask_to_kv_shape,
     generate_block_sparse_pattern,
-    generate_ranges_from_block_mask,
+    generate_ranges_from_block_mask_triton,
 )
 
 # isort: off
@@ -229,9 +228,12 @@ def prepare_block_sparse_ffa_args(
         device=device,
     )
     # flat_mask = flatten_block_mask(block_mask, nhq, nhk)
-    flat_mask = flatten_block_mask_to_kv_shape(block_mask)
-    q_ranges, k_ranges = generate_ranges_from_block_mask(
-        flat_mask, q_block_size, k_block_size
+    # flat_mask = flatten_block_mask_to_kv_shape(block_mask)
+    # q_ranges, k_ranges = generate_ranges_from_block_mask(
+    #     flat_mask, q_block_size, k_block_size
+    # )
+    q_ranges, k_ranges = generate_ranges_from_block_mask_triton(
+        block_mask, q_block_size, k_block_size
     )
     attn_type_map = torch.zeros(q_ranges.shape[0], dtype=torch.int32, device=device)
     args = {

--- a/exps/attn/run_packgqa_bench.py
+++ b/exps/attn/run_packgqa_bench.py
@@ -21,6 +21,7 @@ from baselines.utils import seed_everything
 from einops import rearrange
 
 from magi_attention.benchmarking import Benchmark, do_bench_flops, perf_report
+from magi_attention.common.sparse_args import FFaSparseArgs
 from magi_attention.utils.sparse_utils import (
     flatten_block_mask_to_kv_shape,
     generate_block_sparse_pattern,
@@ -221,10 +222,12 @@ def sparse_attn_benchmark(
                     q_ranges=q_ranges,
                     k_ranges=k_ranges,
                     attn_type_map=attn_type_map,
-                    auto_range_merge=True,  # we should enable auto_range_merge for block sparse mask.
-                    ref_block_size=ref_block_size,
-                    pack_gqa=False,
                     disable_fwd_atomic_reduction=True,
+                    sparse_args=FFaSparseArgs(
+                        auto_range_merge=True,  # we should enable auto_range_merge for block sparse mask.
+                        ffa_tile_size=ref_block_size,
+                        pack_gqa=False,
+                    ),
                 )
 
             if wd == "bwd":
@@ -263,10 +266,12 @@ def sparse_attn_benchmark(
                     q_ranges=q_ranges,
                     k_ranges=k_ranges,
                     attn_type_map=attn_type_map,
-                    auto_range_merge=True,  # we should enable auto_range_merge for block sparse mask.
-                    ref_block_size=ref_block_size,
-                    pack_gqa=True,
                     disable_fwd_atomic_reduction=True,
+                    sparse_args=FFaSparseArgs(
+                        auto_range_merge=True,  # we should enable auto_range_merge for block sparse mask.
+                        ffa_tile_size=ref_block_size,
+                        pack_gqa=True,
+                    ),
                 )
 
             if wd == "bwd":

--- a/exps/attn/run_sparse_load_block_sparse_benchmark.py
+++ b/exps/attn/run_sparse_load_block_sparse_benchmark.py
@@ -21,6 +21,7 @@ from baselines.utils import block_sparse_available, seed_everything
 from einops import rearrange
 
 from magi_attention.benchmarking import Benchmark, do_bench_flops, perf_report
+from magi_attention.common.sparse_args import FFaSparseArgs
 from magi_attention.utils.sparse_utils import (
     generate_block_sparse_pattern,
     generate_ranges_from_block_mask_triton,
@@ -216,10 +217,12 @@ def sparse_attn_benchmark(
                     q_ranges=q_ranges,
                     k_ranges=k_ranges,
                     attn_type_map=attn_type_map,
-                    auto_range_merge=True,
-                    sparse_load=sparse_load,
-                    ref_block_size=ref_block_size,
                     disable_fwd_atomic_reduction=True,
+                    sparse_args=FFaSparseArgs(
+                        auto_range_merge=True,
+                        sparse_load=sparse_load,
+                        ffa_tile_size=ref_block_size,
+                    ),
                 )
 
             if wd == "bwd":

--- a/exps/attn/run_sparse_load_pack_gqa_benchmark.py
+++ b/exps/attn/run_sparse_load_pack_gqa_benchmark.py
@@ -21,6 +21,7 @@ from baselines.utils import block_sparse_available, seed_everything
 from einops import rearrange
 
 from magi_attention.benchmarking import Benchmark, do_bench_flops, perf_report
+from magi_attention.common.sparse_args import FFaSparseArgs
 from magi_attention.utils.sparse_utils import (
     generate_block_sparse_pattern,
     generate_ranges_from_block_mask_triton,
@@ -203,11 +204,13 @@ def sparse_attn_benchmark(
                     q_ranges=q_ranges,
                     k_ranges=k_ranges,
                     attn_type_map=attn_type_map,
-                    auto_range_merge=True,
-                    sparse_load=sparse_load,
-                    pack_gqa=pack_gqa,
-                    ref_block_size=ref_block_size,
                     disable_fwd_atomic_reduction=True,
+                    sparse_args=FFaSparseArgs(
+                        auto_range_merge=True,
+                        sparse_load=sparse_load,
+                        pack_gqa=pack_gqa,
+                        ffa_tile_size=ref_block_size,
+                    ),
                 )
 
             if wd == "bwd":

--- a/magi_attention/common/sparse_args.py
+++ b/magi_attention/common/sparse_args.py
@@ -149,8 +149,8 @@ class FFaSparseArgs:
             ), "ref_block_size must be (8, 64), (16, 64), (32, 64) or (64, 64) when swap_ab == True"
         elif self.sparse_load:
             assert (
-                kblock_n == 128
-            ), "sparse load requires kblock_n == 128 in ffa_tile_size"
+                kblock_n == 128 or kblock_n == 64
+            ), "sparse load requires kblock_n == 128 or 64 in ffa_tile_size"
         else:
             # TODO: K>128 support?
             assert kblock_m in (
@@ -169,9 +169,6 @@ class FFaSparseArgs:
             RuntimeError: If the configuration is invalid.
         """
         self.validate_tile_size()
-        if self.sparse_load and self.swap_ab:
-            # FIXME: support both optimizations together
-            raise RuntimeError("swap_ab and sparse_load cannot be enabled together.")
         if self.sparse_load and not self.auto_range_merge:
             raise RuntimeError(
                 "When using sparse load, range merge must be enabled "

--- a/magi_attention/common/sparse_args.py
+++ b/magi_attention/common/sparse_args.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025-2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sparse attention optimization arguments for Flexible Flash Attention.
+
+This module provides a dataclass for configuring sparse attention optimizations,
+including swap_ab, pack_gqa, sparse_load, and other related parameters.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class FFaSparseArgs:
+    """Configuration arguments for sparse attention optimization in Flexible Flash Attention.
+
+    This dataclass encapsulates all parameters related to sparse attention optimization,
+    making it easier to manage and pass these parameters as a group.
+
+    The FFA internal tile size is automatically selected by the kernel based on the
+    ref_block_size parameter in flex_flash_attn_func, or can be manually specified
+    through the choose_ref_block utility.
+
+    Attributes:
+        ffa_tile_size: Internal tile size configuration for FFA kernel (M, N).
+            Defaults to (128, 128).
+        swap_ab: Whether to use swap_ab mode for optimizing performance when q_range size
+            is small (<= 16). Defaults to False.
+        pack_gqa: Whether to group query heads sharing the same KV head into a single
+            computation block tile for small seqlen_q scenarios. This method significantly
+            improves the computational efficiency of block sparse attention when seqlen_q
+            is small. Defaults to False.
+        sparse_load: Whether to enable sparse load mode for optimizing performance when
+            k_range size is small (<= 64). Must be used together with auto_range_merge=True
+            for enhanced performance. Defaults to False.
+        auto_range_merge: Whether to automatically merge k_ranges for the same q_range.
+            This flag is useful for sparse attention scenarios. Defaults to True.
+        max_seqlen_q: Maximum sequence length for query. If provided, enables optimization
+            for tile_scheduler. Most recommended to set this when using auto_range_merge
+            (for block sparse attention). Defaults to None.
+
+    Example:
+        >>> # 1. Auto-tune from ref_block_size (Recommended)
+        >>> # The kernel will automatically select the best parameters based on ref_block_size.
+        >>> out, lse = flex_flash_attn_func(
+        ...     q, k, v, q_ranges, k_ranges,
+        ...     ref_block_size=(64, 32)
+        ... )
+        >>>
+        >>> # 2. Manual control (Advanced)
+        >>> # Manually specify optimization parameters using FFaSparseArgs.
+        >>> sparse_args = FfaSparseArgs(
+        ...     ffa_tile_size=(128, 128),
+        ...     auto_range_merge=True,
+        ...     sparse_load=True,
+        ...     max_seqlen_q=64
+        ... )
+        >>> out, lse = flex_flash_attn_func(
+        ...     q, k, v, q_ranges, k_ranges,
+        ...     sparse_args=sparse_args
+        ... )
+    """
+
+    ffa_tile_size: tuple[int, int] = (128, 128)
+    swap_ab: bool = False
+    pack_gqa: bool = False
+    sparse_load: bool = False
+    auto_range_merge: bool = True
+    max_seqlen_q: int | None = None
+
+    @classmethod
+    def from_ref_block_size(
+        cls,
+        ref_block_size: tuple[int, int],
+        qhead_per_khead: int,
+    ) -> "FFaSparseArgs":
+        """Auto-tune and create FfaSparseArgs from ref_block_size and qhead_per_khead.
+
+        This method uses the choose_ref_block utility to automatically determine
+        the best FFA internal parameters based on the given ref_block_size.
+
+        The auto-tuning rules (from sparse_utils.choose_ref_block):
+        - SwapAB and sparse load can't be enabled together
+        - Prioritize sparse load and packGQA in small Q/K blocks
+        - For k_block_size <= 64:
+            - sparse_load = True, internal tile size K = 128
+        - For k_block_size > 64:
+            - internal tile size K is a multiple of 16, capped at 128
+        - For q_block_size < 128:
+            - pack_gqa = True if qhead_per_khead > 1
+            - If q_block_size * qhead_per_khead <= 16 and not sparse_load: swap_ab = True
+            - Otherwise: internal tile size M is a multiple of 64, capped at 128
+        - For q_block_size >= 128:
+            - pack_gqa = False, swap_ab = False
+            - internal tile size M is a multiple of 64, capped at 128
+
+        Args:
+            ref_block_size: A tuple of (q_block_size, k_block_size) representing the
+                most common (mode) user's Q/K block sizes.
+            qhead_per_khead: The number of query heads per key head (GQA group size).
+
+        Returns:
+            FfaSparseArgs: An instance with auto-tuned parameters (excluding ffa_tile_size
+                which is handled internally by the kernel).
+
+        Example:
+            >>> sparse_args = FfaSparseArgs.from_ref_block_size(
+            ...     ref_block_size=(64, 32),
+            ...     qhead_per_khead=4
+            ... )
+        """
+        from magi_attention.utils.sparse_utils import choose_ref_block
+
+        params = choose_ref_block(ref_block_size, qhead_per_khead)
+        return cls(
+            ffa_tile_size=params["ref_block_size"],
+            swap_ab=params["swap_ab"],
+            pack_gqa=params["pack_gqa"],
+            sparse_load=params["sparse_load"],
+            max_seqlen_q=ref_block_size[0],  # default to ref q_block_size
+            auto_range_merge=True,  # default to True for sparse attention
+        )
+
+    def validate_tile_size(self) -> None:
+        if self.ffa_tile_size is None:
+            raise RuntimeError(
+                "If manually setting FfaSparseArgs, ffa_tile_size must be specified."
+            )
+        kblock_m, kblock_n = self.ffa_tile_size
+        if self.swap_ab:
+            assert self.ffa_tile_size in (
+                (8, 64),
+                (16, 64),
+                (32, 64),
+                (64, 64),
+            ), "ref_block_size must be (8, 64), (16, 64), (32, 64) or (64, 64) when swap_ab == True"
+        elif self.sparse_load:
+            assert (
+                kblock_n == 128
+            ), "sparse load requires kblock_n == 128 in ffa_tile_size"
+        else:
+            # TODO: K>128 support?
+            assert kblock_m in (
+                64,
+                128,
+                192,
+            ), "ref_block_size: (kblock_m, kblock_n), kblock_m must be 64, 128 or 192 when swapab == False"
+            assert (
+                kblock_n % 16 == 0 and kblock_n <= 128
+            ), "ref_block_size: (kblock_m, kblock_n), kblock_n <= 128 and kblock_n % 16 == 0 must be True"
+
+    def validate(self) -> None:
+        """Validate the sparse arguments configuration.
+
+        Raises:
+            RuntimeError: If the configuration is invalid.
+        """
+        self.validate_tile_size()
+        if self.sparse_load and self.swap_ab:
+            # FIXME: support both optimizations together
+            raise RuntimeError("swap_ab and sparse_load cannot be enabled together.")
+        if self.sparse_load and not self.auto_range_merge:
+            raise RuntimeError(
+                "When using sparse load, range merge must be enabled "
+                "(set auto_range_merge to True)."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the sparse arguments to a dictionary.
+
+        Returns:
+            A dictionary containing all the sparse arguments.
+        """
+        return {
+            "ffa_tile_size": self.ffa_tile_size,
+            "swap_ab": self.swap_ab,
+            "pack_gqa": self.pack_gqa,
+            "sparse_load": self.sparse_load,
+            "auto_range_merge": self.auto_range_merge,
+            "max_seqlen_q": self.max_seqlen_q,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "FFaSparseArgs":
+        """Create FfaSparseArgs from a dictionary.
+
+        Args:
+            d: A dictionary containing sparse arguments.
+
+        Returns:
+            FfaSparseArgs: An instance created from the dictionary.
+        """
+        return cls(
+            ffa_tile_size=d.get("ffa_tile_size", (128, 128)),
+            swap_ab=d.get("swap_ab", False),
+            pack_gqa=d.get("pack_gqa", False),
+            sparse_load=d.get("sparse_load", False),
+            auto_range_merge=d.get("auto_range_merge", True),
+            max_seqlen_q=d.get("max_seqlen_q"),
+        )
+
+
+# Default instance with all optimizations disabled
+DEFAULT_SPARSE_ARGS = FFaSparseArgs()

--- a/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
+++ b/magi_attention/csrc/flexible_flash_attention/flash_fwd_kernel_sm90.h
@@ -266,115 +266,71 @@ class FlashAttnFwdSm90 {
     TileScheduler scheduler(reinterpret_cast<typename TileScheduler::SharedStorage*>(&shared_storage.pipelines.smem_scheduler));
 
     if (warp_group_idx == 0) { // Producer
-      if constexpr (!SparseLoad) {
-        // normal load using TMA
-        using BlockMetaT = typename CollectiveMainloop::BlockMeta<true>;
+      // normal load using TMA
+      using BlockMetaT = std::conditional_t<!SparseLoad, typename CollectiveMainloop::BlockMeta<true>, typename CollectiveMainloop::SparseLoadBlockMeta>;
+      int thread_idx = threadIdx.x % NumProducerThreads;
 
-        // Deallocate the registers for the producer WG, this makes the consumer
-        // WG have more registers
-        cutlass::arch::warpgroup_reg_dealloc<LoadRegisterRequirement>();
+      // Deallocate the registers for the producer WG, this makes the consumer
+      // WG have more registers
+      cutlass::arch::warpgroup_reg_dealloc<LoadRegisterRequirement>();
 
-        // Initialize the producer pipeline state
-        PipelineState smem_pipe_write_k = cutlass::make_producer_start_state<MainloopPipelineK>();
-        PipelineState smem_pipe_write_v = cutlass::make_producer_start_state<MainloopPipelineV>();
+      // Initialize the producer pipeline state
+      PipelineState smem_pipe_write_k = cutlass::make_producer_start_state<MainloopPipelineK>();
+      PipelineState smem_pipe_write_v = cutlass::make_producer_start_state<MainloopPipelineV>();
 
-        // Initialize the work index
-        int work_idx = 0;
+      // Initialize the work index
+      int work_idx = 0;
 
-        // Get some block-level information
-        int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (threadIdx.x / 32) % 4, 0);
-        // Currently, SingleProducerWarp is always true
-        static constexpr bool SingleProducerWarp = NumProducerThreads == cutlass::NumThreadsPerWarp;
+      // Get some block-level information
+      int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (threadIdx.x / 32) % 4, 0);
+      // true without SparseLoad, false with SparseLoad
+      static constexpr bool SingleProducerWarp = NumProducerThreads == cutlass::NumThreadsPerWarp;
 
-        // Only the first warp in the warp group needs to issue the TMA load
-        // instruction
-        if constexpr (SingleProducerWarp) {
-          if (warp_idx_in_warpgroup != 0) {
-            return;
-          }
+      // If not sparse load, only the first warp in the warp group needs to issue the TMA load instruction
+      // If sparse load, all threads in the warp group need to issue cp.async load cooperatively
+      if constexpr (SingleProducerWarp) {
+        if (warp_idx_in_warpgroup != 0) {
+          return;
         }
+      }
 
-        // wtfff?
+      // wtfff?
+      if constexpr (!SparseLoad) {
         if (!SingleProducerWarp && warp_idx_in_warpgroup != 0) {
           scheduler.init_consumer();
         }
-
-        // cutlass::arch::wait_on_dependent_grids();
-        // Load Q, K, V
-        for (auto work_tile_info = SingleProducerWarp || warp_idx_in_warpgroup == 0 ? scheduler.template get_initial_work</*IsProducerWarp=*/true>(params.scheduler)
-                                                                                    : scheduler.template get_initial_work</*IsProducerWarp=*/false>(params.scheduler);
-             work_tile_info.is_valid(params.scheduler);
-             work_tile_info = SingleProducerWarp || warp_idx_in_warpgroup == 0
-                 ? scheduler.template get_next_work</*IsProducerWarp=*/true>(params.scheduler, work_tile_info)
-                 : scheduler.template get_next_work</*IsProducerWarp=*/false>(params.scheduler, work_tile_info)) {
-          BlockCoordType block_coord_raw = work_tile_info.get_block_coord(params.scheduler);
-          // get block_coord without deterministic message
-          auto block_coord = cute::make_tuple(get<0>(block_coord_raw), get<1>(block_coord_raw), get<2>(block_coord_raw));
-          auto scheduler_prefetch = [&scheduler, &params, &work_tile_info]() { scheduler.prefetch_next_work(params.scheduler, work_tile_info); };
-
-          BlockMetaT block_meta = BlockMetaT{params.mainloop, block_coord, shared_storage};
-
-          bool has_tile_valid = mainloop.load(
-              params.mainloop, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v, shared_storage, scheduler_prefetch, block_coord, block_meta, work_idx);
-
-          scheduler_prefetch();
-          if (has_tile_valid) {
-            ++work_idx;
-          }
-        }
-        mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v, shared_storage, work_idx);
-      } else {
-        using BlockMetaT = typename CollectiveMainloop::SparseLoadBlockMeta;
-
-        // Deallocate the registers for the producer WG, this makes the consumer
-        // WG have more registers
-        cutlass::arch::warpgroup_reg_dealloc<LoadRegisterRequirement>();
-
-        // Initialize the producer pipeline state
-        PipelineState smem_pipe_write_k = cutlass::make_producer_start_state<MainloopPipelineK>();
-        PipelineState smem_pipe_write_v = cutlass::make_producer_start_state<MainloopPipelineV>();
-
-        // Initialize the work index
-        int work_idx = 0;
-
-        // Get some block-level information
-        int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (threadIdx.x / 32) % 4, 0);
-        int thread_idx = threadIdx.x % NumProducerThreads;
-
-        // Load Q, K, V
-        // Only let the first warp as producer warp to do scheduling, otherwise cause atomicAdd issues in tile scheduler
-        for (auto work_tile_info = warp_idx_in_warpgroup == 0 ? scheduler.template get_initial_work</*IsProducerWarp=*/true>(params.scheduler)
-                                                              : scheduler.template get_initial_work</*IsProducerWarp=*/false>(params.scheduler);
-             work_tile_info.is_valid(params.scheduler);
-             work_tile_info = warp_idx_in_warpgroup == 0 ? scheduler.template get_next_work</*IsProducerWarp=*/true>(params.scheduler, work_tile_info)
-                                                         : scheduler.template get_next_work</*IsProducerWarp=*/false>(params.scheduler, work_tile_info)) {
-          BlockCoordType block_coord_raw = work_tile_info.get_block_coord(params.scheduler);
-          // get block_coord without deterministic message
-          auto block_coord = cute::make_tuple(get<0>(block_coord_raw), get<1>(block_coord_raw), get<2>(block_coord_raw));
-          auto scheduler_prefetch = [&scheduler, &params, &work_tile_info]() { scheduler.prefetch_next_work(params.scheduler, work_tile_info); };
-
-          BlockMetaT block_meta = BlockMetaT{params.mainloop, block_coord, shared_storage, thread_idx};
-
-          bool has_tile_valid = mainloop.sparse_load(
-              params.mainloop,
-              pipeline_k,
-              pipeline_v,
-              smem_pipe_write_k,
-              smem_pipe_write_v,
-              shared_storage,
-              scheduler_prefetch,
-              block_coord,
-              block_meta,
-              work_idx,
-              thread_idx);
-
-          scheduler_prefetch();
-          if (has_tile_valid) {
-            ++work_idx;
-          }
-        }
-        mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v, shared_storage, work_idx);
       }
+
+      // cutlass::arch::wait_on_dependent_grids();
+      // Load Q, K, V
+      for (auto work_tile_info = SingleProducerWarp || warp_idx_in_warpgroup == 0 ? scheduler.template get_initial_work</*IsProducerWarp=*/true>(params.scheduler)
+                                                                                  : scheduler.template get_initial_work</*IsProducerWarp=*/false>(params.scheduler);
+           work_tile_info.is_valid(params.scheduler);
+           work_tile_info = SingleProducerWarp || warp_idx_in_warpgroup == 0
+               ? scheduler.template get_next_work</*IsProducerWarp=*/true>(params.scheduler, work_tile_info)
+               : scheduler.template get_next_work</*IsProducerWarp=*/false>(params.scheduler, work_tile_info)) {
+        BlockCoordType block_coord_raw = work_tile_info.get_block_coord(params.scheduler);
+        // get block_coord without deterministic message
+        auto block_coord = cute::make_tuple(get<0>(block_coord_raw), get<1>(block_coord_raw), get<2>(block_coord_raw));
+        auto scheduler_prefetch = [&scheduler, &params, &work_tile_info]() { scheduler.prefetch_next_work(params.scheduler, work_tile_info); };
+
+        auto block_meta = [&]() {
+          if constexpr (!SparseLoad) {
+            return BlockMetaT{params.mainloop, block_coord, shared_storage};
+          } else {
+            return BlockMetaT{params.mainloop, block_coord, shared_storage, thread_idx};
+          }
+        }();
+
+        bool has_tile_valid = mainloop.load(
+            params.mainloop, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v, shared_storage, scheduler_prefetch, block_coord, block_meta, work_idx);
+
+        scheduler_prefetch();
+        if (has_tile_valid) {
+          ++work_idx;
+        }
+      }
+      mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v, shared_storage, work_idx);
     } else { // Consumer
       using BlockMetaT = std::conditional_t<!SparseLoad, typename CollectiveMainloop::BlockMeta<false>, typename CollectiveMainloop::SparseMmaBlockMeta>;
 
@@ -420,38 +376,20 @@ class FlashAttnFwdSm90 {
 
         BlockMetaT block_meta = BlockMetaT{params.mainloop, block_coord, shared_storage};
 
-        bool has_tile_valid = false;
-        if constexpr (!SparseLoad) {
-          has_tile_valid = mainloop.mma(
-              params.mainloop,
-              pipeline_k,
-              pipeline_v,
-              smem_pipe_read_k,
-              smem_pipe_read_v,
-              tOrO,
-              softmax,
-              scores_scale,
-              threadIdx.x - MmaThreadOffset,
-              work_idx,
-              block_coord,
-              block_meta,
-              shared_storage);
-        } else {
-          has_tile_valid = mainloop.sparse_mma(
-              params.mainloop,
-              pipeline_k,
-              pipeline_v,
-              smem_pipe_read_k,
-              smem_pipe_read_v,
-              tOrO,
-              softmax,
-              scores_scale,
-              threadIdx.x - MmaThreadOffset,
-              work_idx,
-              block_coord,
-              block_meta,
-              shared_storage);
-        }
+        bool has_tile_valid = mainloop.mma(
+            params.mainloop,
+            pipeline_k,
+            pipeline_v,
+            smem_pipe_read_k,
+            smem_pipe_read_v,
+            tOrO,
+            softmax,
+            scores_scale,
+            threadIdx.x - MmaThreadOffset,
+            work_idx,
+            block_coord,
+            block_meta,
+            shared_storage);
 
         // Do this here before the epilogue so that the next tile is ready to go.
         work_tile_info = scheduler.template get_next_work</*IsProducerWarp=*/false>(params.scheduler, work_tile_info);

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -117,7 +117,6 @@ struct CollectiveMainloopFwdSm90 {
   // Sanity check
   static_assert(Use_TMA_KV || CUTE_STATIC_V(size(ClusterShape{})) == 1, "If not using TMA for KV, ClusterShape must be 1");
   static_assert(ArchTag::kMinComputeCapability >= 90);
-  static_assert(!(SwapAB && SparseLoad), "SwapAB and SparseLoad cannot be enabled at the same time");
 
   // By default, V is always row-major
   static constexpr cute::GMMA::Major MmaMajorV = GMMA::Major::MN;
@@ -135,7 +134,7 @@ struct CollectiveMainloopFwdSm90 {
   static constexpr int GroupSize = 8, NumGroups = 128 / GroupSize;
   // Number of rows (tokens) to load per group
   static constexpr int NumRowsPerGroup = kBlockN / NumGroups;
-  static_assert(!SparseLoad || (NumRowsPerGroup == 8), "When sparse load, only support 8 tokens load for each group");
+  static_assert(!SparseLoad || (kBlockN == 64 || kBlockN == 128), "Sparse load only supports kBlockN = 64 or 128");
 
   using AtomLayoutQK = Layout<Shape<Int<kBlockM / 64>, _1, _1>>;
 
@@ -612,49 +611,55 @@ struct CollectiveMainloopFwdSm90 {
         // 3. corner case for boundary mask: move the valid token index ahead
         int offset = num_invalid_token % NumRowsPerGroup;
         switch (offset) {
-          case 0:
+          case 7:
+            if constexpr (NumRowsPerGroup == 8) {
+              token_indices[6] = token_indices[last_idx];
+              token_indices[5] = token_indices[last_idx - 1];
+              token_indices[4] = token_indices[last_idx - 2];
+              token_indices[3] = token_indices[last_idx - 3];
+              token_indices[2] = token_indices[last_idx - 4];
+              token_indices[1] = token_indices[last_idx - 5];
+              token_indices[0] = token_indices[last_idx - 6];
+            }
             break;
-          case 1:
-            token_indices[0] = token_indices[last_idx];
+          case 6:
+            if constexpr (NumRowsPerGroup == 8) {
+              token_indices[5] = token_indices[last_idx];
+              token_indices[4] = token_indices[last_idx - 1];
+              token_indices[3] = token_indices[last_idx - 2];
+              token_indices[2] = token_indices[last_idx - 3];
+              token_indices[1] = token_indices[last_idx - 4];
+              token_indices[0] = token_indices[last_idx - 5];
+            }
             break;
-          case 2:
-            token_indices[1] = token_indices[last_idx];
-            token_indices[0] = token_indices[last_idx - 1];
+          case 5:
+            if constexpr (NumRowsPerGroup == 8) {
+              token_indices[4] = token_indices[last_idx];
+              token_indices[3] = token_indices[last_idx - 1];
+              token_indices[2] = token_indices[last_idx - 2];
+              token_indices[1] = token_indices[last_idx - 3];
+              token_indices[0] = token_indices[last_idx - 4];
+            }
+            break;
+          case 4:
+            if constexpr (NumRowsPerGroup == 8) {
+              token_indices[3] = token_indices[last_idx];
+              token_indices[2] = token_indices[last_idx - 1];
+              token_indices[1] = token_indices[last_idx - 2];
+              token_indices[0] = token_indices[last_idx - 3];
+            }
             break;
           case 3:
             token_indices[2] = token_indices[last_idx];
             token_indices[1] = token_indices[last_idx - 1];
             token_indices[0] = token_indices[last_idx - 2];
             break;
-          case 4:
-            token_indices[3] = token_indices[last_idx];
-            token_indices[2] = token_indices[last_idx - 1];
-            token_indices[1] = token_indices[last_idx - 2];
-            token_indices[0] = token_indices[last_idx - 3];
+          case 2:
+            token_indices[1] = token_indices[last_idx];
+            token_indices[0] = token_indices[last_idx - 1];
             break;
-          case 5:
-            token_indices[4] = token_indices[last_idx];
-            token_indices[3] = token_indices[last_idx - 1];
-            token_indices[2] = token_indices[last_idx - 2];
-            token_indices[1] = token_indices[last_idx - 3];
-            token_indices[0] = token_indices[last_idx - 4];
-            break;
-          case 6:
-            token_indices[5] = token_indices[last_idx];
-            token_indices[4] = token_indices[last_idx - 1];
-            token_indices[3] = token_indices[last_idx - 2];
-            token_indices[2] = token_indices[last_idx - 3];
-            token_indices[1] = token_indices[last_idx - 4];
-            token_indices[0] = token_indices[last_idx - 5];
-            break;
-          case 7:
-            token_indices[6] = token_indices[last_idx];
-            token_indices[5] = token_indices[last_idx - 1];
-            token_indices[4] = token_indices[last_idx - 2];
-            token_indices[3] = token_indices[last_idx - 3];
-            token_indices[2] = token_indices[last_idx - 4];
-            token_indices[1] = token_indices[last_idx - 5];
-            token_indices[0] = token_indices[last_idx - 6];
+          case 1:
+            token_indices[0] = token_indices[last_idx];
             break;
           default:
             break;
@@ -671,8 +676,8 @@ struct CollectiveMainloopFwdSm90 {
       }
       // update token index for each thread
       if (!is_finish()) {
-        int num_threads = NumProducerThreads;
-        int num_steps = num_threads; // move pointer to the next token, for each thread
+        // move pointer to the next token in the next tile
+        int num_steps = kBlockN;
         int cnt = 0;
         int last_idx = NumRowsPerGroup - 1;
 
@@ -746,6 +751,12 @@ struct CollectiveMainloopFwdSm90 {
     bool is_finish() {
       return cur_loop >= loop_count;
     }
+
+    CUTLASS_DEVICE
+    bool is_valid() {
+      // blocks while applying sparse load are always valid
+      return true;
+    }
   };
 
   // only used when SparseLoad=true
@@ -805,6 +816,12 @@ struct CollectiveMainloopFwdSm90 {
     CUTLASS_DEVICE
     bool is_finish() {
       return cur_loop >= loop_count;
+    }
+
+    CUTLASS_DEVICE
+    bool is_valid() {
+      // blocks while applying sparse load are always valid
+      return true;
     }
   };
 
@@ -913,6 +930,7 @@ struct CollectiveMainloopFwdSm90 {
       int& work_idx) {
     // If this is true, we're guaranteed that only the first warp will execute this function
     static constexpr bool SingleProducerWarp = NumProducerThreads == cutlass::NumThreadsPerWarp;
+    int const thread_idx = threadIdx.x % NumProducerThreads;
 
     // prepare for cluster launch
     uint32_t block_rank_in_cluster = cute::block_rank_in_cluster();
@@ -926,13 +944,15 @@ struct CollectiveMainloopFwdSm90 {
       }
     }
 
-    while (!block_meta.is_finish() && !block_meta.is_valid()) {
-      // Find the first valid block_meta
-      block_meta.prefetch();
+    if constexpr (!SparseLoad) {
+      while (!block_meta.is_finish() && !block_meta.is_valid()) {
+        // Find the first valid block_meta
+        block_meta.prefetch();
+      }
     }
 
     if (block_meta.is_finish()) {
-      // No valid block found
+      // No valid block found or no more blocks to process
       return false;
     }
 
@@ -989,8 +1009,12 @@ struct CollectiveMainloopFwdSm90 {
       Tensor tQsQ = group_modes<0, 3>(block_tma_Q.partition_D(sQ)); // (TMA)
       if constexpr (Use_TMA_Q) {
         // Wait for the MMA warpgroups to signal that smem_q is ready
-        if (SingleProducerWarp || warp_idx_in_warpgroup == 0) {
-          cutlass::arch::NamedBarrier::sync(NumMmaThreadsQK + cutlass::NumThreadsPerWarp, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
+        if constexpr (!SparseLoad) {
+          if (SingleProducerWarp || warp_idx_in_warpgroup == 0) {
+            cutlass::arch::NamedBarrier::sync(NumMmaThreadsQK + cutlass::NumThreadsPerWarp, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
+          }
+        } else {
+          cutlass::arch::NamedBarrier::sync(NumMmaThreadsQK + NumProducerThreads, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
         }
 
         if (is_tma_issue_thread()) {
@@ -1014,63 +1038,129 @@ struct CollectiveMainloopFwdSm90 {
       }
     };
 
+    // Params for Sparse Load
+    int64_t cache_policy = createpolicy_evict_last();
+    int num_tiles = kHeadDim * sizeof(Element) / 128; // each tile load 128B
+    int idx_in_warpgroup = thread_idx % 128;
+    int idx_in_group = idx_in_warpgroup % GroupSize;
+    int group_idx = idx_in_warpgroup / GroupSize;
+
     auto load_K = [&](int const n_block_idx, auto& smem_pipe_write, int offset_k) {
-      // Prepare the TMA load K
-      auto block_tma_K = params.tma_load_K.get_slice(cluster_local_block_id.x);
-      Tensor mK_TMA = params.tma_load_K.get_tma_tensor(params.shape_K)(_, _, block_meta.bidh_kv);
-      Tensor gK_TMA = local_tile(domain_offset(make_coord(offset_k, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{})); // (N, K, _, _)
-      // tma_partition doesn't handle position_independent_swizzle_tensor correctly, so we need to do it manually
-      Tensor tKgK_TMA = group_modes<0, 3>(block_tma_K.partition_S(gK_TMA)); // (TMA, k)
+      if constexpr (!SparseLoad) {
+        // Prepare the TMA load K
+        auto block_tma_K = params.tma_load_K.get_slice(cluster_local_block_id.x);
+        Tensor mK_TMA = params.tma_load_K.get_tma_tensor(params.shape_K)(_, _, block_meta.bidh_kv);
+        Tensor gK_TMA = local_tile(domain_offset(make_coord(offset_k, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{})); // (N, K, _, _)
+        // tma_partition doesn't handle position_independent_swizzle_tensor correctly, so we need to do it manually
+        Tensor tKgK_TMA = group_modes<0, 3>(block_tma_K.partition_S(gK_TMA)); // (TMA, k)
 
-      Tensor sK = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_k.data()), SmemLayoutK{});
-      Tensor tKsK_TMA = group_modes<0, 3>(block_tma_K.partition_D(sK)); // (TMA, PIPE)
+        Tensor sK = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_k.data()), SmemLayoutK{});
+        Tensor tKsK_TMA = group_modes<0, 3>(block_tma_K.partition_D(sK)); // (TMA, PIPE)
 
-      if (is_tma_issue_thread()) {
+        if (is_tma_issue_thread()) {
+          pipeline_k.producer_acquire(smem_pipe_write);
+          copy(
+              params.tma_load_K.with(*pipeline_k.producer_get_barrier(smem_pipe_write), mcast_mask_kv, TMA::CacheHintSm90::EVICT_LAST),
+              tKgK_TMA(_, n_block_idx),
+              tKsK_TMA(_, smem_pipe_write.index()));
+          ++smem_pipe_write;
+        }
+        // =======DEBUG========
+        // if (block_meta.m_block == 0 && threadIdx.x == 0 && block_meta.bidb == 0) {
+        //   printf("shared memory sK: \n");
+        //   cute::print_tensor(sK);
+        // }
+      } else {
         pipeline_k.producer_acquire(smem_pipe_write);
-        copy(
-            params.tma_load_K.with(*pipeline_k.producer_get_barrier(smem_pipe_write), mcast_mask_kv, TMA::CacheHintSm90::EVICT_LAST),
-            tKgK_TMA(_, n_block_idx),
-            tKsK_TMA(_, smem_pipe_write.index()));
+        // Producer Ops. calculate src/dst offset based on token index, then cp.async load
+        // K shape: (seqlen, head_dim, num_heads)
+        // each thread in the same group has a offset 16B (8 elements)
+        Element* ptr_gK_base = params.ptr_K + block_meta.bidh_kv * get<2>(params.stride_K) + idx_in_group * 8;
+        // shared memory pointer
+        Tensor sK = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_k.data()), SmemLayoutK{});
+
+        // loop over token indices
+        CUTE_UNROLL
+        for (int local_row = 0; local_row < NumRowsPerGroup; ++local_row) {
+          int token_idx = block_meta.token_indices[local_row];
+          // loop over number of tiles to load one token
+          CUTE_UNROLL
+          for (int tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+            Element* dst_ptr = &sK(group_idx * NumRowsPerGroup + local_row, idx_in_group * 8 + tile_idx * 64, smem_pipe_write.index());
+            cp_async_cacheglobal_l2_prefetch_256B(ptr_gK_base + token_idx + tile_idx * 64, dst_ptr, true, cache_policy);
+          }
+        }
+
+        pipeline_k.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
         ++smem_pipe_write;
       }
-      // =======DEBUG========
-      // if (block_meta.m_block == 0 && threadIdx.x == 0 && block_meta.bidb == 0) {
-      //   printf("shared memory sK: \n");
-      //   cute::print_tensor(sK);
-      // }
     };
 
     auto load_V = [&](int const n_block_idx, auto& smem_pipe_write, int offset_k) {
-      // Prepare the TMA load V
-      // Shape of V is (headdim, total_tokens, head_kv, batch)
-      auto block_tma_V = params.tma_load_V.get_slice(cluster_local_block_id.x);
-      auto shape_V = make_shape(params.headdim, get<0>(params.shape_K), get<2>(params.shape_K));
+      if constexpr (!SparseLoad) {
+        // Prepare the TMA load V
+        // Shape of V is (headdim, total_tokens, head_kv, batch)
+        auto block_tma_V = params.tma_load_V.get_slice(cluster_local_block_id.x);
+        auto shape_V = make_shape(params.headdim, get<0>(params.shape_K), get<2>(params.shape_K));
 
-      Tensor mVt_TMA = params.tma_load_V.get_tma_tensor(shape_V)(_, _, block_meta.bidh_kv);
-      Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, offset_k), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _)); // (K, N, _, _)
-      Tensor tVgVt_TMA = group_modes<0, 3>(block_tma_V.partition_S(gVt_TMA)); // (TMA, k)
+        Tensor mVt_TMA = params.tma_load_V.get_tma_tensor(shape_V)(_, _, block_meta.bidh_kv);
+        Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, offset_k), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _)); // (K, N, _, _)
+        Tensor tVgVt_TMA = group_modes<0, 3>(block_tma_V.partition_S(gVt_TMA)); // (TMA, k)
 
-      Tensor sVt = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_v.data()), SmemLayoutVt{});
-      Tensor tVsVt_TMA = group_modes<0, 3>(block_tma_V.partition_D(sVt)); // (TMA, PIPE)
+        Tensor sVt = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_v.data()), SmemLayoutVt{});
+        Tensor tVsVt_TMA = group_modes<0, 3>(block_tma_V.partition_D(sVt)); // (TMA, PIPE)
 
-      if (is_tma_issue_thread()) {
+        if (is_tma_issue_thread()) {
+          pipeline_v.producer_acquire(smem_pipe_write);
+          copy(
+              params.tma_load_V.with(*pipeline_v.producer_get_barrier(smem_pipe_write), mcast_mask_kv, TMA::CacheHintSm90::EVICT_LAST),
+              tVgVt_TMA(_, n_block_idx),
+              tVsVt_TMA(_, smem_pipe_write.index()));
+          ++smem_pipe_write;
+        }
+      } else {
         pipeline_v.producer_acquire(smem_pipe_write);
-        copy(
-            params.tma_load_V.with(*pipeline_v.producer_get_barrier(smem_pipe_write), mcast_mask_kv, TMA::CacheHintSm90::EVICT_LAST),
-            tVgVt_TMA(_, n_block_idx),
-            tVsVt_TMA(_, smem_pipe_write.index()));
+        // Producer Ops. calculate src/dst offset based on token index, then cp.async load
+        // V shape: (seqlen, head_dim, num_heads)
+        // each thread in the same group has a offset 16B (8 elements)
+        Element* ptr_gV_base = params.ptr_V + block_meta.bidh_kv * get<2>(params.stride_V) + idx_in_group * 8;
+        // shared memory pointer
+        Tensor sVt = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_v.data()), SmemLayoutVt{});
+
+        // loop over token indices
+        CUTE_UNROLL
+        for (int local_row = 0; local_row < NumRowsPerGroup; ++local_row) {
+          int token_idx = block_meta.prev_token_indices[local_row];
+          // loop over number of tiles to load one token
+          CUTE_UNROLL
+          for (int tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+            Element* dst_ptr = &sVt(idx_in_group * 8 + tile_idx * 64, group_idx * NumRowsPerGroup + local_row, smem_pipe_write.index());
+            cp_async_cacheglobal_l2_prefetch_256B(ptr_gV_base + token_idx + tile_idx * 64, dst_ptr, true, cache_policy);
+          }
+        }
+
+        pipeline_v.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
         ++smem_pipe_write;
       }
     };
 
     // Get n_block for kv
-    int n_block = block_meta.n_block_max - 1;
-    int prev_n_block = n_block;
+    int n_block;
+    int prev_n_block;
     // Get offset for kv
     int offset_k = block_meta.seqlen_info.offset_k;
     int prev_offset_k = offset_k;
     // Get the minimum number of blocks to load
-    int n_block_min = block_meta.n_block_min;
+    int n_block_min;
+    int n_block_max;
+    if constexpr (!SparseLoad) {
+      n_block = block_meta.n_block_max - 1;
+      n_block_min = block_meta.n_block_min;
+      prev_n_block = n_block;
+    } else {
+      n_block = 0;
+      n_block_max = block_meta.loop_count;
+    }
 
     // Prologue
     if constexpr (IntraWGOverlap) {
@@ -1090,210 +1180,46 @@ struct CollectiveMainloopFwdSm90 {
     do {
       // Prefetch the next block_meta
       block_meta.prefetch();
-
-      // Loop until we reach the end of the current block
-#pragma unroll(Use_TMA_KV ? 2 : 1)
-      while (n_block >= n_block_min) {
-        if constexpr (IntraWGOverlap) {
-          load_K(n_block, smem_pipe_write_k, offset_k);
-          load_V(prev_n_block, smem_pipe_write_v, prev_offset_k);
-        } else {
-          load_K(n_block, smem_pipe_write_k, offset_k);
-          load_V(n_block, smem_pipe_write_v, offset_k);
-        }
-
-        // Step the previous n_block and offset_k
-        prev_n_block = n_block;
-        prev_offset_k = offset_k;
-        // Decrement n_block
-        --n_block;
+      if constexpr (SparseLoad) {
+        n_block = block_meta.cur_loop;
       }
 
-      // Step into the next block
-      n_block = block_meta.n_block_max - 1;
-      offset_k = block_meta.seqlen_info.offset_k;
-      n_block_min = block_meta.n_block_min;
+      // Loop until we reach the end of the current block
+      if constexpr (!SparseLoad) {
+#pragma unroll 2
+        while (n_block >= n_block_min) {
+          if constexpr (IntraWGOverlap) {
+            load_K(n_block, smem_pipe_write_k, offset_k);
+            load_V(prev_n_block, smem_pipe_write_v, prev_offset_k);
+          } else {
+            load_K(n_block, smem_pipe_write_k, offset_k);
+            load_V(n_block, smem_pipe_write_v, offset_k);
+          }
+
+          // Step the previous n_block and offset_k
+          prev_n_block = n_block;
+          prev_offset_k = offset_k;
+          // Decrement n_block
+          --n_block;
+        }
+
+        // Step into the next block
+        n_block = block_meta.n_block_max - 1;
+        offset_k = block_meta.seqlen_info.offset_k;
+        n_block_min = block_meta.n_block_min;
+      } else {
+        if (n_block < n_block_max) {
+          // Load interleaved K/V
+          if constexpr (IntraWGOverlap) {
+            load_K(n_block, smem_pipe_write_k, offset_k);
+            load_V(prev_n_block, smem_pipe_write_v, prev_offset_k);
+          }
+        }
+      }
     } while (!block_meta.is_finish() && block_meta.is_valid());
 
     // Epilogue, load the tail V
     load_V(prev_n_block, smem_pipe_write_v, prev_offset_k);
-
-    return true;
-  }
-
-  template <typename SchedulerPrefetch, typename SharedStorage, typename BlockMetaT>
-  CUTLASS_DEVICE bool sparse_load(
-      Params const& params,
-      MainloopPipelineK pipeline_k,
-      MainloopPipelineV pipeline_v,
-      PipelineState& smem_pipe_write_k,
-      PipelineState& smem_pipe_write_v,
-      SharedStorage& shared_storage,
-      SchedulerPrefetch const& scheduler_prefetch,
-      cute::tuple<int32_t, int32_t, int32_t> const& block_coord,
-      BlockMetaT& block_meta,
-      int& work_idx,
-      int const thread_idx) {
-    if (block_meta.is_finish()) {
-      // No more blocks to process
-      return false;
-    }
-
-    int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (threadIdx.x / 32) % 4, 0);
-    auto is_tma_issue_thread = [&]() { return (warp_idx_in_warpgroup == 0) && cute::elect_one_sync(); };
-
-    // Define utility lambdas to load Q (TMA load)
-    auto load_Q = [&]() {
-      auto block_tma_Q = params.tma_load_Q.get_slice(_0{});
-      auto block_tma_Q_Packed = params.tma_load_Q_packed.get_slice(_0{});
-      Tensor mQ = params.tma_load_Q.get_tma_tensor(params.shape_Q)(_, _, block_meta.bidh);
-
-      Tensor mQ_Packed = [&]() {
-        if constexpr (PackGQA) {
-          return params.tma_load_Q_packed.get_tma_tensor(params.shape_Q_packed)(_, _, block_meta.bidh);
-        } else {
-          return mQ;
-        }
-      }();
-
-      Tensor gQ = local_tile(
-          domain_offset(make_coord(block_meta.seqlen_info.offset_q, _0{}), mQ), select<0, 2>(TileShape_MNK{}), make_coord(block_meta.m_block, _0{})); // (M, K)
-
-      Tensor gQ_Packed = [&]() {
-        if constexpr (PackGQA) {
-          return local_tile(
-              domain_offset(
-                  make_coord(block_meta.seqlen_info.offset_q * Qhead_per_khead, _0{}),
-                  mQ_Packed), // for packgqa, we need multiple qhead_per_khead for offset of seqlen;
-              select<0, 2>(TileShape_MNK{}),
-              make_coord(block_meta.m_block, _0{})); // (M // qhead_per_khead, K, qhead_per_khead)
-        } else {
-          return gQ;
-        }
-      }();
-
-      Tensor tQgQ = group_modes<0, 3>(block_tma_Q.partition_S(gQ)); // (TMA)
-
-      Tensor tQgQ_Packed = [&]() {
-        if constexpr (PackGQA) {
-          return group_modes<0, 3>(block_tma_Q_Packed.partition_S(gQ_Packed));
-        } else {
-          return tQgQ;
-        }
-      }();
-
-      Tensor sQ = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_q.data()), SmemLayoutQ{});
-      Tensor tQsQ = group_modes<0, 3>(block_tma_Q.partition_D(sQ)); // (TMA)
-
-      if constexpr (Use_TMA_Q) {
-        // Wait for the MMA warpgroups to signal that smem_q is ready
-        // if (warp_idx_in_warpgroup == 0) {
-        cutlass::arch::NamedBarrier::sync(NumMmaThreadsQK + NumProducerThreads, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
-        // }
-        if (is_tma_issue_thread()) {
-          shared_storage.pipelines.barrier_Q.arrive_and_expect_tx(TmaTransactionBytesQ);
-
-          if constexpr (PackGQA) {
-            auto tma_desc = params.tma_load_Q_packed.with(
-                reinterpret_cast<typename cutlass::arch::ClusterTransactionBarrier::ValueType&>(shared_storage.pipelines.barrier_Q),
-                0 /*mcast_mask*/,
-                TMA::CacheHintSm90::EVICT_FIRST);
-
-            copy(tma_desc, tQgQ_Packed, tQsQ);
-          } else {
-            auto tma_desc = params.tma_load_Q.with(
-                reinterpret_cast<typename cutlass::arch::ClusterTransactionBarrier::ValueType&>(shared_storage.pipelines.barrier_Q),
-                0 /*mcast_mask*/,
-                TMA::CacheHintSm90::EVICT_FIRST);
-            copy(tma_desc, tQgQ, tQsQ);
-          }
-        }
-      }
-    };
-
-    int64_t cache_policy = createpolicy_evict_last();
-
-    int num_tiles = kHeadDim * sizeof(Element) / 128; // each tile load 128B
-    int idx_in_warpgroup = thread_idx % 128;
-    int idx_in_group = idx_in_warpgroup % GroupSize;
-    int group_idx = idx_in_warpgroup / GroupSize;
-
-    // ======Coalesced Load======
-    auto load_K = [&](auto& smem_pipe_write) {
-      pipeline_k.producer_acquire(smem_pipe_write);
-      // Producer Ops. calculate src/dst offset based on token index, then cp.async load
-      // K shape: (seqlen, head_dim, num_heads)
-      // each thread in the same group has a offset 16B (8 elements)
-      Element* ptr_gK_base = params.ptr_K + block_meta.bidh_kv * get<2>(params.stride_K) + idx_in_group * 8;
-      // shared memory pointer
-      Tensor sK = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_k.data()), SmemLayoutK{});
-
-      // loop over token indices
-      CUTE_UNROLL
-      for (int local_row = 0; local_row < NumRowsPerGroup; ++local_row) {
-        int token_idx = block_meta.token_indices[local_row];
-        // loop over number of tiles to load one token
-        CUTE_UNROLL
-        for (int tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-          Element* dst_ptr = &sK(group_idx * NumRowsPerGroup + local_row, idx_in_group * 8 + tile_idx * 64, smem_pipe_write.index());
-          cp_async_cacheglobal_l2_prefetch_256B(ptr_gK_base + token_idx + tile_idx * 64, dst_ptr, true, cache_policy);
-        }
-      }
-
-      pipeline_k.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
-      ++smem_pipe_write;
-    };
-
-    auto load_V = [&](auto& smem_pipe_write) {
-      pipeline_v.producer_acquire(smem_pipe_write);
-      // Producer Ops. calculate src/dst offset based on token index, then cp.async load
-      // V shape: (seqlen, head_dim, num_heads)
-      // each thread in the same group has a offset 16B (8 elements)
-      Element* ptr_gV_base = params.ptr_V + block_meta.bidh_kv * get<2>(params.stride_V) + idx_in_group * 8;
-      // shared memory pointer
-      Tensor sVt = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_v.data()), SmemLayoutVt{});
-
-      // loop over token indices
-      CUTE_UNROLL
-      for (int local_row = 0; local_row < NumRowsPerGroup; ++local_row) {
-        int token_idx = block_meta.prev_token_indices[local_row];
-        // loop over number of tiles to load one token
-        CUTE_UNROLL
-        for (int tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-          Element* dst_ptr = &sVt(idx_in_group * 8 + tile_idx * 64, group_idx * NumRowsPerGroup + local_row, smem_pipe_write.index());
-          cp_async_cacheglobal_l2_prefetch_256B(ptr_gV_base + token_idx + tile_idx * 64, dst_ptr, true, cache_policy);
-        }
-      }
-
-      pipeline_v.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
-      ++smem_pipe_write;
-    };
-
-    // Prologue
-    int n_block_max = block_meta.loop_count;
-    if constexpr (IntraWGOverlap) {
-      load_K(smem_pipe_write_k);
-      load_Q();
-      shared_storage.pipelines.barrier_O.wait((work_idx + 1) % 2);
-    }
-
-    do {
-      // Prefetch the next block_meta
-      block_meta.prefetch();
-      int n_block = block_meta.cur_loop;
-
-      if (n_block < n_block_max) {
-        // Load interleaved K/V
-        if constexpr (IntraWGOverlap) {
-          load_K(smem_pipe_write_k);
-          load_V(smem_pipe_write_v);
-        }
-      }
-
-    } while (!block_meta.is_finish());
-
-    // Epilogue, load the tail V
-    load_V(smem_pipe_write_v);
 
     return true;
   }
@@ -1309,7 +1235,7 @@ struct CollectiveMainloopFwdSm90 {
     // If we don't wait for barrier_O here, when using Cluster, CTA0 might exit early and CTA1 will
     // try to arrive on barrier_O of CTA0, causing "unspecified launch failure".
     shared_storage.pipelines.barrier_O.wait((work_idx + 1) % 2);
-    if (!SparseLoad) {
+    if constexpr (!SparseLoad) {
       int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (threadIdx.x / 32) % 4, 0);
       // Issue the epilogue waits
       // TODO: check if this should be called by 1 thread or more
@@ -1364,7 +1290,7 @@ struct CollectiveMainloopFwdSm90 {
     int warp_group_idx = flash::canonical_warp_group_idx_nosync();
 
     // Tell producers that smem_q is ready to be loaded
-    if (!SparseLoad) {
+    if constexpr (!SparseLoad) {
       cutlass::arch::NamedBarrier::arrive(
           NumMmaThreadsQK + (Use_TMA_Q ? cutlass::NumThreadsPerWarp : NumProducerThreads), static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
     } else {
@@ -1529,9 +1455,11 @@ struct CollectiveMainloopFwdSm90 {
       cute::copy(smem_tiled_copy_Q, tSsQ_copy_view, tSrQ_copy_view);
     }
 
-    while (!block_meta.is_finish() && !block_meta.is_valid()) {
-      // Find the first valid block_meta
-      block_meta.prefetch();
+    if constexpr (!SparseLoad) {
+      while (!block_meta.is_finish() && !block_meta.is_valid()) {
+        // Find the first valid block_meta
+        block_meta.prefetch();
+      }
     }
 
     if (block_meta.is_finish()) {
@@ -1553,11 +1481,24 @@ struct CollectiveMainloopFwdSm90 {
     // }
 
     // Get n_block for kv
-    int n_block = block_meta.n_block_max - 1;
+    int n_block;
     // Get seqlen for kv
     int seqlen_k = block_meta.seqlen_info.seqlen_k;
     // Get the minimum number of blocks to calculate
-    int n_block_min = block_meta.n_block_min;
+    int n_block_min;
+    // Get the maximum number of blocks to calculate (for sparse load)
+    int n_block_max;
+
+    if constexpr (!SparseLoad) {
+      n_block = block_meta.n_block_max - 1;
+      n_block_min = block_meta.n_block_min;
+      n_block_max = 0;
+    } else {
+      n_block = 0;
+      n_block_min = 0;
+      n_block_max = block_meta.loop_count;
+    }
+
     // Get attention type for n_block
     flash::AttnType attn_type = block_meta.attn_type;
     // Get mask for n_block
@@ -1569,7 +1510,11 @@ struct CollectiveMainloopFwdSm90 {
     // boundary_mask_fn: mask for boundary block, for the rightmost block in a tile job
     auto bypass_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) {};
     auto boundary_mask_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) {
-      mask.template apply<true /*Seqlenk_mask*/, PackGQA, Qhead_per_khead>(tSrS, block_meta.m_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
+      if constexpr (!SparseLoad) {
+        mask.template apply<true /*Seqlenk_mask*/, PackGQA, Qhead_per_khead>(tSrS, block_meta.m_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
+      } else {
+        mask.template apply_sparse_load(tSrS, block_meta.num_invalid_token, thread_idx);
+      }
     };
     // no_mask_fn: no mask, for full attention block in a tile job
     auto no_mask_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) {
@@ -1626,9 +1571,9 @@ struct CollectiveMainloopFwdSm90 {
 
     /** DEBUG **/
     // if (block_meta.bidb == 0 && block_meta.bidb == 0 && block_meta.m_block == 0 && thread_idx == 0) {
-    //     printf("============================================ tSrS after mask m_block: %d, thread_idx: %d ==============================\n", block_meta.m_block,
-    //     thread_idx); print_tensor(tSrS); printf("============================================ tSrS after mask m_block: %d, thread_idx: %d
-    //     ==============================\n", block_meta.m_block, thread_idx);
+    //     printf("========== tSrS after mask m_block: %d, thread_idx: %d =========\n", block_meta.m_block, thread_idx);
+    //     print_tensor(tSrS);
+    //     printf("========== tSrS after mask m_block: %d, thread_idx: %d =========\n", block_meta.m_block, thread_idx);
     // }
     // Get row-max and row-sum of tSrS
     cute::copy(softmax.template max_get_scale</*Is_first=*/true, /*Check_inf=*/true, NumMmaWarpGroups>(tSrS), scores_scale);
@@ -1672,7 +1617,11 @@ struct CollectiveMainloopFwdSm90 {
       arrive_on_P_write_barrier();
     }
 
-    --n_block;
+    if constexpr (!SparseLoad) {
+      --n_block;
+    } else {
+      ++n_block; // iterate from 0 to loop_count - 1
+    }
 
 /* ================================================= Mainloop ================================================= */
 #pragma unroll 2
@@ -1743,7 +1692,10 @@ struct CollectiveMainloopFwdSm90 {
         scoremod_premask_fn(tSrS);
 
         // Apply mask
-        mask_fn(tSrS, n_block, attn_type, block_meta.seqlen_info.seqlen_q, seqlen_k);
+        // no operation for sparse load, only supports full attention types
+        if constexpr (!SparseLoad) {
+          mask_fn(tSrS, n_block, attn_type, block_meta.seqlen_info.seqlen_q, seqlen_k);
+        }
 
         // if (bidb == 1 && bidh == 0 && thread_idx == 255 && m_block == 1) {
         //     printf("============================================ tSrS fwd before online_softmax m_block: %d ==============================\n", m_block);
@@ -1790,58 +1742,73 @@ struct CollectiveMainloopFwdSm90 {
       // Prefetch the next block_meta
       block_meta.prefetch();
 
-      if (n_block >= n_block_min && seqlen_k % kBlockN == 0 && attn_type == flash::AttnType::Full) {
-        // If seqlen_k is a multiple of kBlockN, we can skip the boundary mask for the first n_block
-        fwd_step(n_block, bypass_fn, cute::true_type{} /*check_inf*/);
-        --n_block;
-        finish_boundary = true;
-      }
+      if constexpr (!SparseLoad) {
+        if (n_block >= n_block_min && seqlen_k % kBlockN == 0 && attn_type == flash::AttnType::Full) {
+          // If seqlen_k is a multiple of kBlockN, we can skip the boundary mask for the first n_block
+          fwd_step(n_block, bypass_fn, cute::true_type{} /*check_inf*/);
+          --n_block;
+          finish_boundary = true;
+        }
 
-      if (n_block >= n_block_min) {
-        if (attn_type == flash::AttnType::Causal || attn_type == flash::AttnType::BiCausal) {
-          int const m_idx_min = block_meta.m_block * kBlockM;
-          int const n_block_min_causal_local_mask = std::max(n_block_min, (m_idx_min + seqlen_k - block_meta.seqlen_info.seqlen_q) / kBlockN);
+        if (n_block >= n_block_min) {
+          if (attn_type == flash::AttnType::Causal || attn_type == flash::AttnType::BiCausal) {
+            int const m_idx_min = block_meta.m_block * kBlockM;
+            int const n_block_min_causal_local_mask = std::max(n_block_min, (m_idx_min + seqlen_k - block_meta.seqlen_info.seqlen_q) / kBlockN);
 #pragma unroll 1
-          for (; n_block >= n_block_min_causal_local_mask; --n_block) {
-            fwd_step(n_block, regular_mask_fn, cute::true_type{} /*check_inf*/);
+            for (; n_block >= n_block_min_causal_local_mask; --n_block) {
+              fwd_step(n_block, regular_mask_fn, cute::true_type{} /*check_inf*/);
+            }
+          }
+
+          // Calculate the number of iterations needed before the left boundary of inv-causal and bi-causal, where we can skip applying mask to speed up
+          int const m_idx_max = (block_meta.m_block + 1) * kBlockM;
+          int const n_block_min_before_inv_causal_mask =
+              attn_type == flash::AttnType::Full || attn_type == flash::AttnType::Causal ? n_block_min : cute::ceil_div(m_idx_max, kBlockN);
+          // Skip applying mask to the iterations before the left boundary of inv-causal and bi-causal, where we can skip applying mask to speed up
+#pragma unroll 1
+          for (; n_block >= n_block_min_before_inv_causal_mask; --n_block) {
+            fwd_step(n_block, no_mask_fn, cute::false_type{} /*check_inf*/);
+          }
+
+          // Separate masking iterations on the left for inv-causal and bi-causal attention, because they are both top-left aligned
+          if (attn_type == flash::AttnType::InvCausal || attn_type == flash::AttnType::BiCausal) {
+#pragma unroll 1
+            for (; n_block >= n_block_min; --n_block) {
+              fwd_step(n_block, regular_mask_fn, cute::true_type{} /*check_inf*/);
+            }
           }
         }
 
-        // Calculate the number of iterations needed before the left boundary of inv-causal and bi-causal, where we can skip applying mask to speed up
-        int const m_idx_max = (block_meta.m_block + 1) * kBlockM;
-        int const n_block_min_before_inv_causal_mask =
-            attn_type == flash::AttnType::Full || attn_type == flash::AttnType::Causal ? n_block_min : cute::ceil_div(m_idx_max, kBlockN);
-        // Skip applying mask to the iterations before the left boundary of inv-causal and bi-causal, where we can skip applying mask to speed up
-#pragma unroll 1
-        for (; n_block >= n_block_min_before_inv_causal_mask; --n_block) {
-          fwd_step(n_block, no_mask_fn, cute::false_type{} /*check_inf*/);
-        }
-
-        // Separate masking iterations on the left for inv-causal and bi-causal attention, because they are both top-left aligned
-        if (attn_type == flash::AttnType::InvCausal || attn_type == flash::AttnType::BiCausal) {
-#pragma unroll 1
-          for (; n_block >= n_block_min; --n_block) {
-            fwd_step(n_block, regular_mask_fn, cute::true_type{} /*check_inf*/);
+        // Step into the next block
+        n_block = block_meta.n_block_max - 1;
+        seqlen_k = block_meta.seqlen_info.seqlen_k;
+        n_block_min = block_meta.n_block_min;
+        attn_type = block_meta.attn_type;
+        finish_boundary = []() {
+          if constexpr (RangeMerge) {
+            return false;
+          } else {
+            return true;
           }
+        }();
+      } else {
+        n_block = block_meta.cur_loop;
+        if (n_block < n_block_max && attn_type == flash::AttnType::Full) {
+          fwd_step(n_block, bypass_fn, cute::true_type{} /*check_inf*/);
+          ++n_block;
         }
-      }
 
-      // Step into the next block
-      n_block = block_meta.n_block_max - 1;
-      seqlen_k = block_meta.seqlen_info.seqlen_k;
-      n_block_min = block_meta.n_block_min;
-      attn_type = block_meta.attn_type;
-      finish_boundary = []() {
-        if constexpr (RangeMerge) {
-          return false;
-        } else {
-          return true;
-        }
-      }();
+        // Step into the next block
+        attn_type = block_meta.attn_type;
+      }
     } while (!block_meta.is_finish() && block_meta.is_valid());
 
-    cutlass::arch::NamedBarrier::arrive(
-        NumMmaThreadsQK + (Use_TMA_Q ? cutlass::NumThreadsPerWarp : NumProducerThreads), static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
+    if constexpr (!SparseLoad) {
+      cutlass::arch::NamedBarrier::arrive(
+          NumMmaThreadsQK + (Use_TMA_Q ? cutlass::NumThreadsPerWarp : NumProducerThreads), static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
+    } else {
+      cutlass::arch::NamedBarrier::arrive(NumMmaThreadsQK + NumProducerThreads, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
+    }
 
     // Only rescale tOrO if RescaleOBeforeGemm is enabled
     if constexpr (RescaleOBeforeGemm) {
@@ -1884,340 +1851,6 @@ struct CollectiveMainloopFwdSm90 {
     // Rescale tOrO
     softmax.rescale_o(tOrO, scores_scale);
 
-    return true;
-  }
-
-  template <typename SharedStorage, typename FrgTensorO, typename Softmax, typename ScoresScale, typename BlockMetaT>
-  CUTLASS_DEVICE bool sparse_mma(
-      Params const& params,
-      MainloopPipelineK pipeline_k,
-      MainloopPipelineV pipeline_v,
-      PipelineState& smem_pipe_read_k,
-      PipelineState& smem_pipe_read_v,
-      FrgTensorO& tOrO,
-      Softmax& softmax,
-      ScoresScale& scores_scale,
-      int const thread_idx,
-      int& work_idx,
-      cute::tuple<int32_t, int32_t, int32_t> const& block_coord,
-      BlockMetaT& block_meta,
-      SharedStorage& shared_storage) {
-    static_assert(is_rmem<FrgTensorO>::value, "O tensor must be rmem resident.");
-    static constexpr int kBlockM = get<0>(TileShape_MNK{});
-    static constexpr int kBlockN = get<1>(TileShape_MNK{});
-
-    Tensor sQ = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_q.data()), SmemLayoutQ{});
-    Tensor sK = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_k.data()), SmemLayoutK{});
-    Tensor sV = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_v.data()), SmemLayoutVtMma{});
-    Tensor sP = [&] {
-      if constexpr (MmaPV_is_RS) {
-        // We might not have smem_p if !MmaPV_is_RS, just use smem_q as a placeholder since we don't use it
-        return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_q.data()), SmemLayoutP{});
-      } else {
-        return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_p.data()), SmemLayoutP{});
-      }
-    }();
-
-    TiledMmaQK_Active tiled_mma_qk;
-    TiledMmaPV_Active tiled_mma_pv;
-
-    if constexpr (!MmaQK_is_RS) {
-      static_assert(
-          stride<0>(typename TiledMmaQK_Active::ALayout{}) == 0 and stride<0>(typename TiledMmaQK_Active::BLayout{}) == 0 and
-              size<0>(typename TiledMmaQK_Active::ALayout{}) == cutlass::NumThreadsPerWarpGroup and
-              size<0>(typename TiledMmaQK_Active::BLayout{}) == cutlass::NumThreadsPerWarpGroup,
-          "Stride of the first mode must be 0 and the size of the mode must be NumThreadsPerWarpGroup");
-    }
-
-    static constexpr int MmaWarpGroups = size(TiledMmaPV_Active{}) / cutlass::NumThreadsPerWarpGroup;
-    Layout warp_group_thread_layout = make_layout(make_shape(Int<MmaWarpGroups>{}), make_stride(Int<cutlass::NumThreadsPerWarpGroup>{}));
-
-    // Get the mma warp group index of the current thread, start from 0
-    int warp_group_idx = __shfl_sync(0xFFFFFFFF, thread_idx / cutlass::NumThreadsPerWarpGroup, 0);
-    auto wg_mma_qk = tiled_mma_qk.get_slice(warp_group_thread_layout(warp_group_idx));
-    auto wg_mma_pv = tiled_mma_pv.get_slice(warp_group_thread_layout(warp_group_idx));
-
-    auto smem_tiled_copy_P = make_tiled_copy_C(SmemCopyAtomP{}, tiled_mma_qk);
-    auto smem_thr_copy_P = smem_tiled_copy_P.get_thread_slice(thread_idx);
-
-    // Allocate "fragments/descriptors"
-    Tensor tSrQ = wg_mma_qk.partition_fragment_A(sQ);
-    Tensor tSrK = wg_mma_qk.partition_fragment_B(sK);
-    Tensor tOrV = wg_mma_pv.partition_fragment_B(sV);
-    Tensor tOsP = wg_mma_pv.partition_fragment_A(sP);
-    // if p is in registers, do we still need this step ?
-    Tensor tPsP = smem_thr_copy_P.partition_D(cute::as_position_independent_swizzle_tensor(sP));
-
-    // Allocate S(Q@K) fragment
-    Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_MNK{}));
-
-    auto consumer_wait = [](auto& pipeline, auto& smem_pipe_read) {
-      auto barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
-      pipeline.consumer_wait(smem_pipe_read, barrier_token);
-    };
-
-    auto consumer_release = [](auto& pipeline, auto& smem_pipe_read) {
-      pipeline.consumer_release(smem_pipe_read);
-      ++smem_pipe_read;
-    };
-
-    // Softcapping needs to happen before masking since if we apply after masking, softcapping
-    // can turn -inf to e.g. -50.0, which can affect the attention softmax.
-    auto scoremod_premask_fn = [&](auto& tSrS) {
-      if constexpr (Has_softcap) {
-        flash::apply_softcap(tSrS, params.softcap_val);
-      }
-    };
-
-    auto write_P_to_smem = [&](auto& tOrP) { cute::copy(smem_tiled_copy_P, smem_thr_copy_P.retile_S(tOrP), tPsP); };
-
-    auto arrive_on_P_write_barrier = [&] {
-      cutlass::arch::fence_view_async_shared();
-      __syncwarp(); // Only need syncwarp since each warp is using its own P values for MmaPV
-    };
-
-    auto& barrier_Q = shared_storage.pipelines.barrier_Q;
-
-    if constexpr (MmaQK_is_RS) {
-      // MmaQK_is_RS is always false, so we never enter this branch
-      using SmemCopyAtomQ = Copy_Atom<cute::SM75_U32x4_LDSM_N, Element>;
-      auto smem_tiled_copy_Q = make_tiled_copy_A(SmemCopyAtomQ{}, tiled_mma_qk);
-      auto smem_thr_copy_Q = smem_tiled_copy_Q.get_thread_slice(thread_idx);
-      Tensor tSrQ_copy_view = smem_thr_copy_Q.retile_D(tSrQ);
-      Tensor tSsQ_copy_view = smem_thr_copy_Q.partition_S(cute::as_position_independent_swizzle_tensor(sQ));
-      cute::copy(smem_tiled_copy_Q, tSsQ_copy_view, tSrQ_copy_view);
-    }
-
-    if (block_meta.is_finish()) {
-      // No more blocks to process
-      return false;
-    }
-
-    // if (block_meta.bidb == 0 && block_meta.bidh == 0 && thread_idx == 0 && block_meta.m_block == 0) {
-    //   printf(
-    //       "initial block_meta: m_block: %d, n_block_min: %d, n_block_max: %d, seqlen_q: %d, seqlen_k: %d, attn_type: %d\n",
-    //       block_meta.m_block,
-    //       block_meta.n_block_min,
-    //       block_meta.n_block_max,
-    //       block_meta.seqlen_info.seqlen_q,
-    //       block_meta.seqlen_info.seqlen_k,
-    //       block_meta.attn_type
-    //   );
-    // }
-
-    // Get n_block for kv
-    int n_block_max = block_meta.loop_count;
-    int n_block = 0;
-    // // Get attention type for n_block
-    flash::AttnType attn_type = block_meta.attn_type;
-    // Get mask for n_block
-    flash::Mask<kBlockM, kBlockN, TiledMmaQK_Active> mask;
-
-    /* ================================================= Prologue ================================================= */
-    // Wait for the Q to be loaded
-    barrier_Q.wait(work_idx % 2);
-    // Wait for first block of k to be loaded
-    consumer_wait(pipeline_k, smem_pipe_read_k);
-
-    // launch Q @ K of n_block and wait for it to finish
-    flash::gemm</*zero_init=*/true, /*wg_wait=*/-1>(tiled_mma_qk, tSrQ, tSrK(_, _, _, smem_pipe_read_k.index()), tSrS);
-    warpgroup_wait<0>();
-    // if (block_meta.bidb == 0 && block_meta.m_block == 0 && thread_idx == 0) {
-    //     printf("============================================ tSrS m_block: %d ==============================\n", block_meta.m_block);
-    //     print_tensor(tSrS);
-    //     printf("============================================ tSrS m_block: %d ==============================\n", block_meta.m_block);
-    // }
-
-    // The first block of k has been consumed, notify producer that this buffer can be reused
-    consumer_release(pipeline_k, smem_pipe_read_k);
-
-    // Apply score-modification-function(currently only support softcap) before mask
-    scoremod_premask_fn(tSrS);
-    // if (bidb == 0 && bidh == 0 && thread_idx == 0 && m_block == 0) {
-    //     printf("============================================ tSrS m_block: %d ==============================\n", m_block);
-    //     print_tensor(tSrS);
-    //     printf("============================================ tSrS m_block: %d ==============================\n", m_block);
-    // }
-
-    // Apply boundary mask
-    mask.template apply_sparse_load(tSrS, block_meta.num_invalid_token, thread_idx);
-    // if (block_meta.bidb == 0 && block_meta.m_block == 0 && thread_idx == 0) {
-    //     printf("============================================ tSrS after mask m_block: %d, thread_idx: %d ==============================\n", block_meta.m_block,
-    //     thread_idx); print_tensor(tSrS); printf("============================================ tSrS after mask m_block: %d, thread_idx: %d
-    //     ==============================\n", block_meta.m_block, thread_idx);
-    // }
-    // Get row-max and row-sum of tSrS
-    cute::copy(softmax.template max_get_scale</*Is_first=*/true, /*Check_inf=*/true>(tSrS), scores_scale);
-    // if (bidb == 0 && bidh == 0 && thread_idx == 0 && m_block == 0) {
-    //     printf("============================================ scores_scale m_block: %d ==============================\n", m_block);
-    //     print_tensor(scores_scale);
-    //     printf("============================================ scores_scale m_block: %d ==============================\n", m_block);
-    // }
-
-    // Apply exponential to tSrS
-    softmax.template online_softmax</*Is_first=*/true, /*Check_inf=*/true>(tSrS);
-    // if (bidb == 0 && bidh == 0 && thread_idx == 0 && m_block == 0) {
-    //     printf("============================================ tSrS after online_softmax m_block: %d ==============================\n", m_block);
-    //     print_tensor(tSrS);
-    //     printf("============================================ tSrS after online_softmax m_block: %d ==============================\n", m_block);
-    // }
-
-    // Convert layout and type from tSrS to tOrP which will be used in MmaPV
-    Tensor tOrP = [&]() {
-      Tensor tOrP_acc = make_tensor(tSrS.data(), flash::convert_layout_acc_Aregs<TiledMmaPV_Active>(tSrS.layout()));
-      Tensor tOrP = make_tensor_like<Element>(tOrP_acc);
-      convert_type_out(tOrP_acc, tOrP);
-      return tOrP;
-    }();
-
-    // Write tOrP to smem
-    if constexpr (!MmaPV_is_RS) {
-      write_P_to_smem(tOrP);
-      // what's the purpose of this fence?
-      arrive_on_P_write_barrier();
-    }
-
-    ++n_block; // iterate from 0 to loop_count - 1
-
-/* ================================================= Mainloop ================================================= */
-#pragma unroll 2
-    do {
-      // Each step does Q @ K for iter n_block, P @ V for iter n_block + 1, and softmax for iter n_block.
-      auto fwd_step = [&](int const n_block, auto check_inf_type) {
-        // Forward step: perform gemm0 (Q@K), gemm1 (P@V) and softmax in an interleaved fashion
-
-        // Extract the boolean value from the check_inf_type template parameter to determine if we need to check for infinity values
-        static constexpr bool Check_inf = decltype(check_inf_type)::value;
-
-        // Partition the fragment C tensor into a new tensor tSrS, which is used to store the result of the Q@K matrix multiplication for n_block
-        Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_MNK{}));
-
-        // If UseSchedulerBarrier is not enabled, all threads need to call consumer_wait, otherwise only threads in the 0th mma warp group call consumer_wait
-        if (!UseSchedulerBarrier || warp_group_idx == 0) {
-          consumer_wait(pipeline_k, smem_pipe_read_k);
-        }
-
-        // Sync on the current mma warp group's named barrier, and wait for the previous mma warp group to finish
-        warp_scheduler_barrier_sync();
-
-        // Do Q @ K of n_block
-        flash::gemm</*zero_init=*/true, /*wg_wait=*/-1>(tiled_mma_qk, tSrQ, tSrK(_, _, _, smem_pipe_read_k.index()), tSrS);
-
-        if constexpr (RescaleOBeforeGemm) {
-          softmax.rescale_o(tOrO, scores_scale);
-        }
-
-        if (!UseSchedulerBarrier || warp_group_idx == 0) {
-          // Wait for v to be loaded into shared memory
-          consumer_wait(pipeline_v, smem_pipe_read_v);
-        }
-
-        // Do p @ v of n_block - 1
-        flash::gemm</*zero_init=*/false, /*wg_wait=*/-1>(
-            tiled_mma_pv, cute::conditional_return<MmaPV_is_RS>(tOrP, tOsP), tOrV(_, _, _, smem_pipe_read_v.index()), tOrO);
-
-        // Arrive on the next mma warp group's named barrier
-        warp_scheduler_barrier_arrive();
-
-        // Only wait for the Q @ K of n_block to finish
-        warpgroup_wait<1>();
-
-        // Signal that the current stage's K smem has been used up, can continue loading subsequent K
-        consumer_release(pipeline_k, smem_pipe_read_k);
-
-        // Apply score-modification-function(currently only support softcap) before mask
-        scoremod_premask_fn(tSrS);
-
-        // Apply mask (no operation here because sparse load only supports full attention types)
-
-        // if (bidb == 1 && bidh == 0 && thread_idx == 255 && m_block == 1) {
-        //     printf("============================================ tSrS fwd before online_softmax m_block: %d ==============================\n", m_block);
-        //     print_tensor(tSrS);
-        //     printf("============================================ tSrS fwd before online_softmax m_block: %d ==============================\n", m_block);
-        // }
-
-        // Get row-max and row-sum of tSrS
-        cute::copy(softmax.template max_get_scale</*Is_first=*/false, Check_inf>(tSrS), scores_scale);
-
-        // Apply exponential to tSrS (need to subtract row max)
-        softmax.template online_softmax</*Is_first=*/false, Check_inf>(tSrS);
-        // if (bidb == 1 && bidh == 0 && thread_idx == 255 && m_block == 1) {
-        //     printf("============================================ tSrS fwd after online_softmax m_block: %d ==============================\n", m_block);
-        //     print_tensor(tSrS);
-        //     printf("============================================ tSrS fwd after online_softmax m_block: %d ==============================\n", m_block);
-        // }
-
-        // Wait for P @ V of n_block + 1 to finish
-        warpgroup_wait<0>();
-
-        // Signal that the current stage's V smem has been used up, can continue loading subsequent V
-        consumer_release(pipeline_v, smem_pipe_read_v);
-
-        // Convert layout and type from tSrS to tOrP
-        convert_type_out(make_tensor(tSrS.data(), tOrP.layout()), tOrP);
-
-        // Write tOrP to smem
-        if constexpr (!MmaPV_is_RS) {
-          write_P_to_smem(tOrP);
-        }
-
-        // Only rescale tOrO if RescaleOBeforeGemm is not enabled
-        if constexpr (!RescaleOBeforeGemm) {
-          softmax.rescale_o(tOrO, scores_scale);
-        }
-
-        // what's the purpose of this fence?
-        if constexpr (!MmaPV_is_RS) {
-          arrive_on_P_write_barrier();
-        }
-      };
-
-      // Prefetch the next block_meta
-      block_meta.prefetch();
-      n_block = block_meta.cur_loop;
-
-      if (n_block < n_block_max && attn_type == flash::AttnType::Full) {
-        fwd_step(n_block, cute::true_type{} /*check_inf*/);
-        ++n_block;
-      }
-
-      // Step into the next block
-      attn_type = block_meta.attn_type;
-    } while (!block_meta.is_finish());
-
-    cutlass::arch::NamedBarrier::arrive(NumMmaThreadsQK + NumProducerThreads, static_cast<uint32_t>(FwdNamedBarriers::QueryEmpty) /*id*/);
-
-    // Only rescale tOrO if RescaleOBeforeGemm is enabled
-    if constexpr (RescaleOBeforeGemm) {
-      softmax.rescale_o(tOrO, scores_scale);
-    }
-
-    // Signal that the current stage's V smem has been used up, can continue loading subsequent V
-    consumer_wait(pipeline_v, smem_pipe_read_v);
-
-    // Do P @ V for the most left n_block
-    flash::gemm</*zero_init=*/false, /*wg_wait=*/-1>(tiled_mma_pv, cute::conditional_return<MmaPV_is_RS>(tOrP, tOsP), tOrV(_, _, _, smem_pipe_read_v.index()), tOrO);
-
-    // Get the final scores_scale
-    cute::copy(softmax.finalize(), scores_scale);
-
-    // if (bidb == 1 && bidh == 0 && thread_idx == 255 && m_block == 1) {
-    //     printf("============================================ tOrO m_block: %d ==============================\n", m_block);
-    //     print_tensor(tOrO);
-    //     printf("============================================ scores_scale m_block: %d ==============================\n", m_block);
-    //     print_tensor(scores_scale);
-    //     printf("============================================ tOrO m_block: %d ==============================\n", m_block);
-    // }
-
-    // Wait for P @ V of the most left n_block to finish
-    warpgroup_wait<0>();
-
-    // Signal that the current stage's V smem has been used up, can continue loading subsequent V
-    consumer_release(pipeline_v, smem_pipe_read_v);
-    ++work_idx;
-
-    // Rescale tOrO
-    softmax.rescale_o(tOrO, scores_scale);
     return true;
   }
 };

--- a/magi_attention/functional/__init__.py
+++ b/magi_attention/functional/__init__.py
@@ -15,11 +15,12 @@
 
 from .dispatch import dispatch_func, undispatch_func
 from .dist_attn import dist_attn_func
-from .flex_flash_attn import flex_flash_attn_func
+from .flex_flash_attn import block_sparse_attn, flex_flash_attn_func
 from .utils import correct_attn_fwd_result, correct_attn_lse, correct_attn_out
 
 __all__ = [
     "flex_flash_attn_func",
+    "block_sparse_attn",
     "dist_attn_func",
     "dispatch_func",
     "undispatch_func",

--- a/magi_attention/utils/sparse_utils.py
+++ b/magi_attention/utils/sparse_utils.py
@@ -1125,7 +1125,7 @@ def choose_ref_block(
 
     # Handle k_block_size
     # TODO: is 256 a reasonable number?
-    if k_block_size < 64:
+    if k_block_size <= 64:
         sparse_load = True
         ref_k_block_size = 128
     else:

--- a/magi_attention/utils/sparse_utils.py
+++ b/magi_attention/utils/sparse_utils.py
@@ -1139,14 +1139,12 @@ def choose_ref_block(
 
         # Determine swap_ab and ref_q_block_size based on ref_q_tile_size
         if ref_q_tile_size <= 8:
-            if not sparse_load:
-                swap_ab = True
-                ref_k_block_size = 64
+            swap_ab = True
+            ref_k_block_size = 64
             ref_q_block_size = 8
         elif ref_q_tile_size <= 16:
-            if not sparse_load:
-                swap_ab = True
-                ref_k_block_size = 64
+            swap_ab = True
+            ref_k_block_size = 64
             ref_q_block_size = 16
         else:
             # Tile_M must be a multiple of 64

--- a/tests/test_attn/test_block_sparse_attn.py
+++ b/tests/test_attn/test_block_sparse_attn.py
@@ -1154,6 +1154,14 @@ class TestBlockSparseAttn(DistTestBase):
                 "sparse_load": True,
                 "ref_block_size": (64, 128),
             },
+            {
+                "type": "uniform",
+                "q_size": 16,
+                "k_size": 8,
+                "swap_ab": True,
+                "sparse_load": True,
+                "ref_block_size": (16, 64),
+            },
             # Variable blocks
             {
                 "type": "variable",
@@ -1217,11 +1225,6 @@ class TestBlockSparseAttn(DistTestBase):
         sparse_load = block_config.get("sparse_load", False)
         ref_block_size = block_config.get("ref_block_size", (128, 128))
         max_seqlen_q = None
-
-        # swap_ab and sparse_load can't be True at the same time
-        # since they target different settings
-        if swap_ab and sparse_load:
-            return
 
         # Prepare inputs
         if test_type == "uniform":
@@ -1436,6 +1439,14 @@ class TestBlockSparseAttn(DistTestBase):
                 "sparse_load": True,
                 "ref_block_size": (64, 128),
             },
+            {
+                "type": "uniform",
+                "q_size": 16,
+                "k_size": 8,
+                "swap_ab": True,
+                "sparse_load": True,
+                "ref_block_size": (16, 64),
+            },
         ],
     )
     @parameterize("sparsity_ratio", [0.1, 0.5, 1.0])
@@ -1477,11 +1488,6 @@ class TestBlockSparseAttn(DistTestBase):
         swap_ab = block_config.get("swap_ab", False)
         sparse_load = block_config.get("sparse_load", False)
         ref_block_size = block_config.get("ref_block_size", None)
-
-        # swap_ab and sparse_load can't be True at the same time
-        # since they target different settings
-        if swap_ab and sparse_load:
-            return
 
         max_seqlen_q = q_block_size
         # Prepare inputs

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_utils import run_tests
 
 from magi_attention.common import AttnRanges
 from magi_attention.common.enum import AttnSinkLayout
+from magi_attention.common.sparse_args import FFaSparseArgs
 from magi_attention.functional import flex_flash_attn_func
 from magi_attention.functional.flex_flash_attn import (
     _flex_flash_attn_backward,
@@ -53,7 +54,7 @@ class TestFlexFlashAttn(DistTestBase):
             # general
             {
                 "swap_ab": False,
-                "ref_block_size": None,
+                "ref_block_size": (128, 128),
                 "pack_gqa": False,
                 "sparse_load": False,
             },
@@ -287,7 +288,7 @@ class TestFlexFlashAttn(DistTestBase):
         dv_ref: torch.Tensor,
         dsink_ref: torch.Tensor | None,
         swap_ab: bool,
-        ref_block_size: tuple[int, int] | None,
+        ref_block_size: tuple[int, int],
         pack_gqa: bool,
         test_case: str,
     ) -> list[str]:
@@ -307,18 +308,20 @@ class TestFlexFlashAttn(DistTestBase):
             q=q,
             k=k,
             v=v,
-            max_seqlen_q=None,
             q_ranges=q_ranges_tensor,
             k_ranges=k_ranges_tensor,
             attn_type_map=attn_type_map_tensor,
             sink=sink,
             sink_layout=sink_layout,
-            auto_range_merge=auto_range_merge,
             deterministic=True,
-            swap_ab=swap_ab,
-            ref_block_size=ref_block_size,
-            pack_gqa=pack_gqa,
-            sparse_load=sparse_load,
+            sparse_args=FFaSparseArgs(
+                auto_range_merge=auto_range_merge,
+                swap_ab=swap_ab,
+                pack_gqa=pack_gqa,
+                sparse_load=sparse_load,
+                max_seqlen_q=None,
+                ffa_tile_size=ref_block_size,
+            ),
         )
         o.backward(do)
 
@@ -1041,7 +1044,7 @@ class TestFlexFlashAttn(DistTestBase):
         sparse_load: bool,
         sink_layout: AttnSinkLayout,
         swap_ab: bool,
-        ref_block_size: tuple[int, int] | None,
+        ref_block_size: tuple[int, int],
         pack_gqa: bool,
         test_case: str,
         err_ratio_dict: dict[str, float] = {},
@@ -1140,18 +1143,20 @@ class TestFlexFlashAttn(DistTestBase):
             q=q,
             k=k,
             v=v,
-            max_seqlen_q=max_seqlen_q,
             q_ranges=q_ranges_tensor,
             k_ranges=k_ranges_tensor,
             attn_type_map=attn_type_map_tensor,
             sink=sink,
             sink_layout=sink_layout,
-            auto_range_merge=auto_range_merge,
             deterministic=deterministic,
-            swap_ab=swap_ab,
-            ref_block_size=ref_block_size,
-            pack_gqa=pack_gqa,
-            sparse_load=sparse_load,
+            sparse_args=FFaSparseArgs(
+                auto_range_merge=auto_range_merge,
+                swap_ab=swap_ab,
+                pack_gqa=pack_gqa,
+                sparse_load=sparse_load,
+                max_seqlen_q=max_seqlen_q,
+                ffa_tile_size=ref_block_size,
+            ),
         )
 
         # run ffa backward
@@ -1866,8 +1871,7 @@ class TestFlexFlashAttn(DistTestBase):
             sink_layout=sink_layout,
             # FIXME: compiling does not support auto_range_merge
             # due to custom unique_consecutive_pairs kernel with dynamic output shape
-            auto_range_merge=False,
-            sparse_load=False,
+            sparse_args=FFaSparseArgs(auto_range_merge=False),
         )
         o.backward(do)
         dq, dk, dv, dsink = q.grad, k.grad, v.grad, sink.grad

--- a/tests/test_attn/test_flex_flash_attn.py
+++ b/tests/test_attn/test_flex_flash_attn.py
@@ -85,6 +85,13 @@ class TestFlexFlashAttn(DistTestBase):
                 "pack_gqa": True,
                 "sparse_load": True,
             },
+            # sparse_load & swap_ab
+            {
+                "swap_ab": True,
+                "ref_block_size": (16, 64),
+                "pack_gqa": False,
+                "sparse_load": True,
+            },
             # swap_ab
             {
                 "swap_ab": True,
@@ -110,6 +117,13 @@ class TestFlexFlashAttn(DistTestBase):
                 "ref_block_size": (64, 64),
                 "pack_gqa": True,
                 "sparse_load": False,
+            },
+            # swap_ab & pack_gqa & sparse_load
+            {
+                "swap_ab": True,
+                "ref_block_size": (64, 64),
+                "pack_gqa": True,
+                "sparse_load": True,
             },
         ]
 


### PR DESCRIPTION
work with @KevinZeng08 .
what this pr do:
- refactor sparse load.
- add autotune function for uniform block sparse sceneries.
- add sparse args.
 
TODO:
- add varlen interface.
- refactor test and bench with new interface.
- support causal.
- optimize generate ranges from block mask(Too many qkranges now).
- optimize fwd_sparse_load_preprocess (Too many kranges now for block_mask).
- Add blog.