### PR TITLE
ci: set MAGI_ATTENTION_TEST_BACKEND in CI test step

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -149,7 +149,7 @@ jobs:
           python -c "import magi_attention; print('Wheel Installation and Import Success')"
       - name: Test and Generate coverage report
         run: |
-          coverage run --source magi_attention -m pytest --skip-slow --import-mode=append -qsv ./tests
+          MAGI_ATTENTION_TEST_BACKEND="*SDPA,*FFA" coverage run --source magi_attention -m pytest --skip-slow --import-mode=append -qsv ./tests
           coverage combine
           coverage xml -i
         env:


### PR DESCRIPTION
## Summary
- Set `MAGI_ATTENTION_TEST_BACKEND="*SDPA,*FFA"` in the CI test command to restrict tests to SDPA and FFA backends.
- This avoids timeouts on slow backends during CI runs.

## Note
This PR should be merged before the main feature PR so that CI picks up the updated workflow.