### PR TITLE
perf: fix FWD/BWD stack spill regression from BlockMeta refactor

### DIFF
--- a/exps/attn/run_benchmark.py
+++ b/exps/attn/run_benchmark.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 import os
-import sys
 from datetime import datetime
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 import torch
 from baselines.attn_impl import (
@@ -62,7 +58,7 @@ from magi_attention.utils._utils import make_attn_mask_from_ffa_args
 
 # impls = ["ffa", "fa3", "fa4", "cudnn", "fa2", "flex", "sdpa"]  # all except torch native
 # impls = ["cudnn", "fa4", "ffa_fa4"] # for blackwell
-impls = ["ffa", "fa3"]  # for hopper (cudnn/fa4 excluded to avoid env dependency)
+impls = ["ffa", "cudnn", "fa3", "fa4"]  # for hopper
 
 mask_types = ["full"]
 # mask_types = ["causal"]

--- a/exps/attn/run_benchmark.py
+++ b/exps/attn/run_benchmark.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import os
+import sys
 from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 import torch
 from baselines.attn_impl import (
@@ -58,7 +62,7 @@ from magi_attention.utils._utils import make_attn_mask_from_ffa_args
 
 # impls = ["ffa", "fa3", "fa4", "cudnn", "fa2", "flex", "sdpa"]  # all except torch native
 # impls = ["cudnn", "fa4", "ffa_fa4"] # for blackwell
-impls = ["ffa", "cudnn", "fa3", "fa4"]  # for hopper
+impls = ["ffa", "fa3"]  # for hopper (cudnn/fa4 excluded to avoid env dependency)
 
 mask_types = ["full"]
 # mask_types = ["causal"]

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -356,7 +356,7 @@ struct IndexAttnBlockMeta {
   // IndexAttn always iterates multiple blocks; batch loop is always needed.
   static constexpr bool NeedsBatchLoop = true;
 
-  int const m_block;
+  int const outer_block;
   int const bidh;
   int const bidh_kv;
   int bidb;
@@ -364,22 +364,21 @@ struct IndexAttnBlockMeta {
   flash::SeqlenInfo seqlen_info;
 
   flash::AttnType attn_type = flash::AttnType::Full;
-  int n_block_min = 0;
-  int n_block_max;
+  int inner_block_min = 0;
   int end_batches;
 
   int token_indices[IsProducer ? NumRowsPerGroup_ : 0];
   int prev_token_indices[IsProducer ? NumRowsPerGroup_ : 0];
 
   int cur_loop;
-  int loop_count;
+  int inner_block_max;
   int num_invalid_token;
 
   int const* group_token_ptr;
 
   template <typename ParamsT, typename SharedStorage>
   CUTLASS_DEVICE IndexAttnBlockMeta(ParamsT const& params, cute::tuple<int32_t, int32_t, int32_t> const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : m_block(get<0>(block_coord)), bidh(get<1>(block_coord)), bidh_kv(!PackGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh), group_token_ptr(nullptr) {
+      : outer_block(get<0>(block_coord)), bidh(get<1>(block_coord)), bidh_kv(!PackGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh), group_token_ptr(nullptr) {
     bidb = [&]() {
       if constexpr (RangeMerge) {
         return params.cu_batches[get<2>(block_coord)];
@@ -401,13 +400,12 @@ struct IndexAttnBlockMeta {
 
     seqlen_info.seqlen_k = actual_topk;
     cur_loop = 0;
-    loop_count = (actual_topk + kBlockN_ - 1) / kBlockN_;
-    num_invalid_token = loop_count * kBlockN_ - actual_topk;
-    n_block_max = loop_count;
+    inner_block_max = (actual_topk + kBlockN_ - 1) / kBlockN_;
+    num_invalid_token = inner_block_max * kBlockN_ - actual_topk;
     end_batches = bidb + 1;
 
     if constexpr (IsProducer) {
-      int aligned_total = loop_count * kBlockN_;
+      int aligned_total = inner_block_max * kBlockN_;
       int group_idx = (thread_idx % NumProducerThreads_) / GroupSize_;
       int group_offset = (aligned_total - kBlockN_) + group_idx * NumRowsPerGroup_;
       group_token_ptr = row_ptr + group_offset;
@@ -429,7 +427,7 @@ struct IndexAttnBlockMeta {
 
   CUTLASS_DEVICE
   auto get_epilogue_coord() const {
-    return cute::make_tuple(m_block, bidh, bidb);
+    return cute::make_tuple(outer_block, bidh, bidb);
   }
 
   CUTLASS_DEVICE
@@ -453,7 +451,7 @@ struct IndexAttnBlockMeta {
 
   CUTLASS_DEVICE
   bool is_finish() {
-    return cur_loop >= loop_count;
+    return cur_loop >= inner_block_max;
   }
 
   CUTLASS_DEVICE bool is_valid() {

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -38,6 +38,9 @@ using namespace cute;
 template <bool IsProducer, bool InnerLoopQ, bool RangeMerge, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
 struct DenseBlockMeta {
   // All fields are by-value (no reference data members) to avoid register spilling to stack.
+  // When !RangeMerge, the batch loop runs exactly once; mark it so callers can elide the while(true).
+  static constexpr bool NeedsBatchLoop = RangeMerge;
+
   int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
   int const bidh;
   int const bidh_kv;
@@ -49,18 +52,26 @@ struct DenseBlockMeta {
   int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
   int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
 
-  int2 const* const q_ranges;
-  int2 const* const k_ranges;
-  int const* const attn_type_map;
+  // Only store persistent pointers when RangeMerge (batch loop calls update_attn_and_bounds repeatedly).
+  // For !RangeMerge, pointers are only used once in the constructor and should not consume registers.
+  static constexpr bool kStorePointers = RangeMerge;
+  struct PointerMembers {
+    int2 const* q_ranges;
+    int2 const* k_ranges;
+    int const* attn_type_map;
+  };
+  struct EmptyPointers {};
+  [[no_unique_address]] std::conditional_t<kStorePointers, PointerMembers, EmptyPointers> ptrs_;
 
   template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
   CUTLASS_DEVICE DenseBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : outer_block(get<0>(block_coord)),
-        bidh(get<1>(block_coord)),
-        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
-        q_ranges(params.q_ranges),
-        k_ranges(params.k_ranges),
-        attn_type_map(params.attn_type_map) {
+      : outer_block(get<0>(block_coord)), bidh(get<1>(block_coord)), bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh) {
+    if constexpr (kStorePointers) {
+      ptrs_.q_ranges = params.q_ranges;
+      ptrs_.k_ranges = params.k_ranges;
+      ptrs_.attn_type_map = params.attn_type_map;
+    }
+
     bidb = [&]() {
       if constexpr (RangeMerge) {
         return load_and_broadcast<1>(&params.cu_batches[get<2>(block_coord)]);
@@ -78,14 +89,36 @@ struct DenseBlockMeta {
     }();
 
     if (!is_finish()) {
-      seqlen_info = SeqlenInfo_t{bidb, q_ranges, k_ranges};
-      update_attn_and_bounds();
+      int2 const* q_ranges_local;
+      int2 const* k_ranges_local;
+      int const* attn_type_map_local;
+      if constexpr (kStorePointers) {
+        q_ranges_local = ptrs_.q_ranges;
+        k_ranges_local = ptrs_.k_ranges;
+        attn_type_map_local = ptrs_.attn_type_map;
+      } else {
+        q_ranges_local = params.q_ranges;
+        k_ranges_local = params.k_ranges;
+        attn_type_map_local = params.attn_type_map;
+      }
+      seqlen_info = SeqlenInfo_t{bidb, q_ranges_local, k_ranges_local};
+      attn_type = static_cast<flash::AttnType>(attn_type_map_local ? load_and_broadcast<1>(&attn_type_map_local[bidb]) : 0);
+      if constexpr (!InnerLoopQ) {
+        auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+        inner_block_min = min_;
+        inner_block_max = max_;
+      } else {
+        auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+        inner_block_min = min_;
+        inner_block_max = max_;
+      }
     }
   }
 
   CUTLASS_DEVICE
   void update_attn_and_bounds() {
-    attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
+    static_assert(kStorePointers, "update_attn_and_bounds() requires RangeMerge (stored pointers)");
+    attn_type = static_cast<flash::AttnType>(ptrs_.attn_type_map ? load_and_broadcast<1>(&ptrs_.attn_type_map[bidb]) : 0);
     if constexpr (!InnerLoopQ) {
       auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
       inner_block_min = min_;
@@ -135,6 +168,61 @@ struct DenseBlockMeta {
   }
 };
 
+template <bool IsProducer, bool InnerLoopQ, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
+struct DenseSingleBatchBlockMeta {
+  static constexpr bool NeedsBatchLoop = false;
+
+  int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
+  int const bidh;
+  int const bidh_kv;
+  int bidb;
+
+  SeqlenInfo_t seqlen_info;
+  flash::AttnType attn_type;
+  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
+  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
+
+  template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
+  CUTLASS_DEVICE DenseSingleBatchBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
+      : outer_block(get<0>(block_coord)),
+        bidh(get<1>(block_coord)),
+        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
+        bidb(get<2>(block_coord)) {
+    seqlen_info = SeqlenInfo_t{bidb, params.q_ranges, params.k_ranges};
+    attn_type = static_cast<flash::AttnType>(params.attn_type_map ? load_and_broadcast<1>(&params.attn_type_map[bidb]) : 0);
+    if constexpr (!InnerLoopQ) {
+      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
+    } else {
+      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
+    }
+  }
+
+  CUTLASS_DEVICE
+  void prefetch() {}
+
+  CUTLASS_DEVICE
+  auto get_epilogue_coord() const {
+    return cute::make_tuple(outer_block, bidh, bidb);
+  }
+
+  CUTLASS_DEVICE
+  bool is_valid() {
+    return inner_block_min < inner_block_max;
+  }
+
+  CUTLASS_DEVICE
+  bool is_finish() {
+    return false;
+  }
+
+  CUTLASS_DEVICE
+  void skip_to_first_valid() {}
+};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // SparseLoadBlockMeta: Unified producer/consumer via IsProducer template parameter.
 // Replaces both old SparseLoadBlockMeta AND SparseMmaBlockMeta.
@@ -152,6 +240,9 @@ template <
     int NumProducerThreads_,
     int kBlockN_>
 struct SparseLoadBlockMeta {
+  // SparseLoad always iterates multiple blocks; batch loop is always needed.
+  static constexpr bool NeedsBatchLoop = true;
+
   int const m_block;
   int const bidh;
   int const bidh_kv;
@@ -349,6 +440,9 @@ struct SparseLoadBlockMeta {
 
 template <bool IsProducer, bool RangeMerge, bool PackGQA, int QheadPerKhead, int NumRowsPerGroup_, int NumProducerThreads_, int GroupSize_, int kBlockN_>
 struct IndexAttnBlockMeta {
+  // IndexAttn always iterates multiple blocks; batch loop is always needed.
+  static constexpr bool NeedsBatchLoop = true;
+
   int const m_block;
   int const bidh;
   int const bidh_kv;

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -52,26 +52,18 @@ struct DenseBlockMeta {
   int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
   int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
 
-  // Only store persistent pointers when RangeMerge (batch loop calls update_attn_and_bounds repeatedly).
-  // For !RangeMerge, pointers are only used once in the constructor and should not consume registers.
-  static constexpr bool kStorePointers = RangeMerge;
-  struct PointerMembers {
-    int2 const* q_ranges;
-    int2 const* k_ranges;
-    int const* attn_type_map;
-  };
-  struct EmptyPointers {};
-  [[no_unique_address]] std::conditional_t<kStorePointers, PointerMembers, EmptyPointers> ptrs_;
+  int2 const* const q_ranges;
+  int2 const* const k_ranges;
+  int const* const attn_type_map;
 
   template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
   CUTLASS_DEVICE DenseBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : outer_block(get<0>(block_coord)), bidh(get<1>(block_coord)), bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh) {
-    if constexpr (kStorePointers) {
-      ptrs_.q_ranges = params.q_ranges;
-      ptrs_.k_ranges = params.k_ranges;
-      ptrs_.attn_type_map = params.attn_type_map;
-    }
-
+      : outer_block(get<0>(block_coord)),
+        bidh(get<1>(block_coord)),
+        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
+        q_ranges(params.q_ranges),
+        k_ranges(params.k_ranges),
+        attn_type_map(params.attn_type_map) {
     bidb = [&]() {
       if constexpr (RangeMerge) {
         return load_and_broadcast<1>(&params.cu_batches[get<2>(block_coord)]);
@@ -89,20 +81,8 @@ struct DenseBlockMeta {
     }();
 
     if (!is_finish()) {
-      int2 const* q_ranges_local;
-      int2 const* k_ranges_local;
-      int const* attn_type_map_local;
-      if constexpr (kStorePointers) {
-        q_ranges_local = ptrs_.q_ranges;
-        k_ranges_local = ptrs_.k_ranges;
-        attn_type_map_local = ptrs_.attn_type_map;
-      } else {
-        q_ranges_local = params.q_ranges;
-        k_ranges_local = params.k_ranges;
-        attn_type_map_local = params.attn_type_map;
-      }
-      seqlen_info = SeqlenInfo_t{bidb, q_ranges_local, k_ranges_local};
-      attn_type = static_cast<flash::AttnType>(attn_type_map_local ? load_and_broadcast<1>(&attn_type_map_local[bidb]) : 0);
+      seqlen_info = SeqlenInfo_t{bidb, q_ranges, k_ranges};
+      attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
       if constexpr (!InnerLoopQ) {
         auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
         inner_block_min = min_;
@@ -117,8 +97,7 @@ struct DenseBlockMeta {
 
   CUTLASS_DEVICE
   void update_attn_and_bounds() {
-    static_assert(kStorePointers, "update_attn_and_bounds() requires RangeMerge (stored pointers)");
-    attn_type = static_cast<flash::AttnType>(ptrs_.attn_type_map ? load_and_broadcast<1>(&ptrs_.attn_type_map[bidb]) : 0);
+    attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
     if constexpr (!InnerLoopQ) {
       auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
       inner_block_min = min_;

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -60,6 +60,9 @@ struct DenseBlockMeta {
   CUTLASS_DEVICE DenseBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
       : outer_block(get<0>(block_coord)),
         bidh(get<1>(block_coord)),
+        // When FlattenGQA (PackGQA or CatGQA), the scheduler assigns bidh as
+        // the kv-head index directly. Otherwise bidh is the q-head index and
+        // we need to divide by QheadPerKhead to get bidh_kv.
         bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
         q_ranges(params.q_ranges),
         k_ranges(params.k_ranges),
@@ -145,6 +148,61 @@ struct DenseBlockMeta {
       prefetch();
     }
   }
+};
+
+template <bool IsProducer, bool InnerLoopQ, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
+struct DenseSingleBatchBlockMeta {
+  static constexpr bool NeedsBatchLoop = false;
+
+  int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
+  int const bidh;
+  int const bidh_kv;
+  int bidb;
+
+  SeqlenInfo_t seqlen_info;
+  flash::AttnType attn_type;
+  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
+  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
+
+  template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
+  CUTLASS_DEVICE DenseSingleBatchBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
+      : outer_block(get<0>(block_coord)),
+        bidh(get<1>(block_coord)),
+        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
+        bidb(get<2>(block_coord)) {
+    seqlen_info = SeqlenInfo_t{bidb, params.q_ranges, params.k_ranges};
+    attn_type = static_cast<flash::AttnType>(params.attn_type_map ? load_and_broadcast<1>(&params.attn_type_map[bidb]) : 0);
+    if constexpr (!InnerLoopQ) {
+      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
+    } else {
+      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
+    }
+  }
+
+  CUTLASS_DEVICE
+  void prefetch() {}
+
+  CUTLASS_DEVICE
+  auto get_epilogue_coord() const {
+    return cute::make_tuple(outer_block, bidh, bidb);
+  }
+
+  CUTLASS_DEVICE
+  bool is_valid() {
+    return inner_block_min < inner_block_max;
+  }
+
+  CUTLASS_DEVICE
+  bool is_finish() {
+    return false;
+  }
+
+  CUTLASS_DEVICE
+  void skip_to_first_valid() {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -37,21 +37,19 @@ using namespace cute;
 
 template <bool IsProducer, bool InnerLoopQ, bool RangeMerge, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
 struct DenseBlockMeta {
-  int const& outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
-  int const& bidh;
+  // All fields are by-value (no reference data members) to avoid register spilling to stack.
+  // FWD (!InnerLoopQ): outer_block=m_block, inner_block_min=n_block_min, inner_block_max=n_block_max
+  // BWD (InnerLoopQ):  outer_block=n_block, inner_block_min=m_block_min, inner_block_max=m_block_max
+  int const m_block;     // outer block index (FWD: M-tile row, BWD: reused as generic outer)
+  int const bidh;        // head index
   int const bidh_kv;
   int bidb;
   int end_batches;
 
   SeqlenInfo_t seqlen_info;
   flash::AttnType attn_type;
-  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
-  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
-
-  // Semantic aliases for FWD / BWD readability
-  int const& m_block = outer_block;
-  int& n_block_min = inner_block_min;
-  int& n_block_max = inner_block_max;
+  int n_block_min;       // inner loop lower bound
+  int n_block_max;       // inner loop upper bound
 
   int2 const* const q_ranges;
   int2 const* const k_ranges;
@@ -59,11 +57,8 @@ struct DenseBlockMeta {
 
   template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
   CUTLASS_DEVICE DenseBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : outer_block(get<0>(block_coord)),
+      : m_block(get<0>(block_coord)),
         bidh(get<1>(block_coord)),
-        // When FlattenGQA (PackGQA or CatGQA), the scheduler assigns bidh as
-        // the kv-head index directly. Otherwise bidh is the q-head index and
-        // we need to divide by QheadPerKhead to get bidh_kv.
         bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
         q_ranges(params.q_ranges),
         k_ranges(params.k_ranges),
@@ -94,13 +89,13 @@ struct DenseBlockMeta {
   void update_attn_and_bounds() {
     attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
     if constexpr (!InnerLoopQ) {
-      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
+      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, m_block, bidb, attn_type);
+      n_block_min = min_;
+      n_block_max = max_;
     } else {
-      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
+      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, m_block, bidb, attn_type);
+      n_block_min = min_;
+      n_block_max = max_;
     }
   }
 
@@ -121,12 +116,12 @@ struct DenseBlockMeta {
 
   CUTLASS_DEVICE
   auto get_epilogue_coord() const {
-    return cute::make_tuple(outer_block, bidh, bidb);
+    return cute::make_tuple(m_block, bidh, bidb);
   }
 
   CUTLASS_DEVICE
   bool is_valid() {
-    return inner_block_min < inner_block_max;
+    return n_block_min < n_block_max;
   }
 
   CUTLASS_DEVICE

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -92,9 +92,8 @@ struct DenseBlockMeta {
   CUTLASS_DEVICE
   void update_attn_and_bounds() {
     attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
-    auto [min_, max_] = InnerLoopQ
-        ? BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type)
-        : BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+    auto [min_, max_] = InnerLoopQ ? BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type)
+                                   : BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
     inner_block_min = min_;
     inner_block_max = max_;
   }
@@ -157,7 +156,7 @@ struct SparseLoadBlockMeta {
   // SparseLoad always iterates multiple blocks; batch loop is always needed.
   static constexpr bool NeedsBatchLoop = true;
 
-  int const m_block;
+  int const outer_block; // always m_block for SparseLoad (FWD only)
   int const bidh;
   int const bidh_kv;
   int bidb;
@@ -167,9 +166,9 @@ struct SparseLoadBlockMeta {
 
   int num_invalid_token;
   int cur_loop;
-  int loop_count;
+  int inner_block_max; // total number of sparse load iterations (was loop_count)
 
-  static constexpr int n_block_min = 0;
+  static constexpr int inner_block_min = 0;
 
   int2 const* const q_ranges;
   int2 const* const k_ranges;
@@ -189,7 +188,7 @@ struct SparseLoadBlockMeta {
       cute::tuple<int32_t, int32_t, int32_t> const& block_coord,
       SharedStorage& shared_storage,
       int thread_idx = 0)
-      : m_block(get<0>(block_coord)),
+      : outer_block(get<0>(block_coord)),
         bidh(get<1>(block_coord)),
         bidh_kv(!PackGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
         q_ranges(params.q_ranges),
@@ -211,7 +210,7 @@ struct SparseLoadBlockMeta {
       }
     }();
     cur_loop = 0;
-    loop_count = params.sparse_load_loop_count ? params.sparse_load_loop_count[get<2>(block_coord)] : 0;
+    inner_block_max = params.sparse_load_loop_count ? params.sparse_load_loop_count[get<2>(block_coord)] : 0;
     num_invalid_token = params.sparse_load_invalid_count ? params.sparse_load_invalid_count[get<2>(block_coord)] : 0;
 
     if constexpr (IsProducer) {
@@ -312,7 +311,7 @@ struct SparseLoadBlockMeta {
 
   CUTLASS_DEVICE
   auto get_epilogue_coord() const {
-    return cute::make_tuple(m_block, bidh, bidb);
+    return cute::make_tuple(outer_block, bidh, bidb);
   }
 
   CUTLASS_DEVICE
@@ -330,7 +329,7 @@ struct SparseLoadBlockMeta {
 
   CUTLASS_DEVICE
   bool is_finish() {
-    return cur_loop >= loop_count;
+    return cur_loop >= inner_block_max;
   }
 
   CUTLASS_DEVICE

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -38,18 +38,16 @@ using namespace cute;
 template <bool IsProducer, bool InnerLoopQ, bool RangeMerge, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
 struct DenseBlockMeta {
   // All fields are by-value (no reference data members) to avoid register spilling to stack.
-  // FWD (!InnerLoopQ): outer_block=m_block, inner_block_min=n_block_min, inner_block_max=n_block_max
-  // BWD (InnerLoopQ):  outer_block=n_block, inner_block_min=m_block_min, inner_block_max=m_block_max
-  int const m_block;     // outer block index (FWD: M-tile row, BWD: reused as generic outer)
-  int const bidh;        // head index
+  int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
+  int const bidh;
   int const bidh_kv;
   int bidb;
   int end_batches;
 
   SeqlenInfo_t seqlen_info;
   flash::AttnType attn_type;
-  int n_block_min;       // inner loop lower bound
-  int n_block_max;       // inner loop upper bound
+  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
+  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
 
   int2 const* const q_ranges;
   int2 const* const k_ranges;
@@ -57,7 +55,7 @@ struct DenseBlockMeta {
 
   template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
   CUTLASS_DEVICE DenseBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : m_block(get<0>(block_coord)),
+      : outer_block(get<0>(block_coord)),
         bidh(get<1>(block_coord)),
         bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
         q_ranges(params.q_ranges),
@@ -89,13 +87,13 @@ struct DenseBlockMeta {
   void update_attn_and_bounds() {
     attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
     if constexpr (!InnerLoopQ) {
-      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, m_block, bidb, attn_type);
-      n_block_min = min_;
-      n_block_max = max_;
+      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
     } else {
-      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, m_block, bidb, attn_type);
-      n_block_min = min_;
-      n_block_max = max_;
+      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+      inner_block_min = min_;
+      inner_block_max = max_;
     }
   }
 
@@ -116,12 +114,12 @@ struct DenseBlockMeta {
 
   CUTLASS_DEVICE
   auto get_epilogue_coord() const {
-    return cute::make_tuple(m_block, bidh, bidb);
+    return cute::make_tuple(outer_block, bidh, bidb);
   }
 
   CUTLASS_DEVICE
   bool is_valid() {
-    return n_block_min < n_block_max;
+    return inner_block_min < inner_block_max;
   }
 
   CUTLASS_DEVICE
@@ -154,8 +152,8 @@ template <
     int NumProducerThreads_,
     int kBlockN_>
 struct SparseLoadBlockMeta {
-  int const& m_block;
-  int const& bidh;
+  int const m_block;
+  int const bidh;
   int const bidh_kv;
   int bidb;
   int end_batches;
@@ -167,7 +165,6 @@ struct SparseLoadBlockMeta {
   int loop_count;
 
   static constexpr int n_block_min = 0;
-  int& n_block_max = loop_count;
 
   int2 const* const q_ranges;
   int2 const* const k_ranges;
@@ -352,8 +349,8 @@ struct SparseLoadBlockMeta {
 
 template <bool IsProducer, bool RangeMerge, bool PackGQA, int QheadPerKhead, int NumRowsPerGroup_, int NumProducerThreads_, int GroupSize_, int kBlockN_>
 struct IndexAttnBlockMeta {
-  int const& m_block;
-  int const& bidh;
+  int const m_block;
+  int const bidh;
   int const bidh_kv;
   int bidb;
 

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -85,31 +85,18 @@ struct DenseBlockMeta {
 
     if (!is_finish()) {
       seqlen_info = SeqlenInfo_t{bidb, q_ranges, k_ranges};
-      attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
-      if constexpr (!InnerLoopQ) {
-        auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-        inner_block_min = min_;
-        inner_block_max = max_;
-      } else {
-        auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-        inner_block_min = min_;
-        inner_block_max = max_;
-      }
+      update_attn_and_bounds();
     }
   }
 
   CUTLASS_DEVICE
   void update_attn_and_bounds() {
     attn_type = static_cast<flash::AttnType>(attn_type_map ? load_and_broadcast<1>(&attn_type_map[bidb]) : 0);
-    if constexpr (!InnerLoopQ) {
-      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    } else {
-      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    }
+    auto [min_, max_] = InnerLoopQ
+        ? BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type)
+        : BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
+    inner_block_min = min_;
+    inner_block_max = max_;
   }
 
   CUTLASS_DEVICE
@@ -148,61 +135,6 @@ struct DenseBlockMeta {
       prefetch();
     }
   }
-};
-
-template <bool IsProducer, bool InnerLoopQ, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
-struct DenseSingleBatchBlockMeta {
-  static constexpr bool NeedsBatchLoop = false;
-
-  int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
-  int const bidh;
-  int const bidh_kv;
-  int bidb;
-
-  SeqlenInfo_t seqlen_info;
-  flash::AttnType attn_type;
-  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
-  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
-
-  template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
-  CUTLASS_DEVICE DenseSingleBatchBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : outer_block(get<0>(block_coord)),
-        bidh(get<1>(block_coord)),
-        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
-        bidb(get<2>(block_coord)) {
-    seqlen_info = SeqlenInfo_t{bidb, params.q_ranges, params.k_ranges};
-    attn_type = static_cast<flash::AttnType>(params.attn_type_map ? load_and_broadcast<1>(&params.attn_type_map[bidb]) : 0);
-    if constexpr (!InnerLoopQ) {
-      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    } else {
-      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    }
-  }
-
-  CUTLASS_DEVICE
-  void prefetch() {}
-
-  CUTLASS_DEVICE
-  auto get_epilogue_coord() const {
-    return cute::make_tuple(outer_block, bidh, bidb);
-  }
-
-  CUTLASS_DEVICE
-  bool is_valid() {
-    return inner_block_min < inner_block_max;
-  }
-
-  CUTLASS_DEVICE
-  bool is_finish() {
-    return false;
-  }
-
-  CUTLASS_DEVICE
-  void skip_to_first_valid() {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -147,61 +147,6 @@ struct DenseBlockMeta {
   }
 };
 
-template <bool IsProducer, bool InnerLoopQ, bool FlattenGQA, int QheadPerKhead, typename SeqlenInfo_t, typename BlockMN_t>
-struct DenseSingleBatchBlockMeta {
-  static constexpr bool NeedsBatchLoop = false;
-
-  int const outer_block; // m_block when !InnerLoopQ, n_block when InnerLoopQ
-  int const bidh;
-  int const bidh_kv;
-  int bidb;
-
-  SeqlenInfo_t seqlen_info;
-  flash::AttnType attn_type;
-  int inner_block_min; // n_block_min when !InnerLoopQ, m_block_min when InnerLoopQ
-  int inner_block_max; // n_block_max when !InnerLoopQ, m_block_max when InnerLoopQ
-
-  template <typename ParamsT, typename BlockCoordT, typename SharedStorage>
-  CUTLASS_DEVICE DenseSingleBatchBlockMeta(ParamsT const& params, BlockCoordT const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
-      : outer_block(get<0>(block_coord)),
-        bidh(get<1>(block_coord)),
-        bidh_kv(!FlattenGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh),
-        bidb(get<2>(block_coord)) {
-    seqlen_info = SeqlenInfo_t{bidb, params.q_ranges, params.k_ranges};
-    attn_type = static_cast<flash::AttnType>(params.attn_type_map ? load_and_broadcast<1>(&params.attn_type_map[bidb]) : 0);
-    if constexpr (!InnerLoopQ) {
-      auto [min_, max_] = BlockMN_t::get_n_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    } else {
-      auto [min_, max_] = BlockMN_t::get_m_block_min_max(seqlen_info, outer_block, bidb, attn_type);
-      inner_block_min = min_;
-      inner_block_max = max_;
-    }
-  }
-
-  CUTLASS_DEVICE
-  void prefetch() {}
-
-  CUTLASS_DEVICE
-  auto get_epilogue_coord() const {
-    return cute::make_tuple(outer_block, bidh, bidb);
-  }
-
-  CUTLASS_DEVICE
-  bool is_valid() {
-    return inner_block_min < inner_block_max;
-  }
-
-  CUTLASS_DEVICE
-  bool is_finish() {
-    return false;
-  }
-
-  CUTLASS_DEVICE
-  void skip_to_first_valid() {}
-};
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // SparseLoadBlockMeta: Unified producer/consumer via IsProducer template parameter.
 // Replaces both old SparseLoadBlockMeta AND SparseMmaBlockMeta.

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -1037,14 +1037,7 @@ struct CollectiveMainloopBwdSm90 {
     // load first block of K,V before the loop, since K,V are shared across all m blocks in the n block
     load_KV();
 
-    // MainLoop: load Q,dO,LSE,dPsum across m_blocks, with while(true) for RangeMerge batch iteration
-    // K/V are loaded once (fixed n_block), Q/dO are streamed across merged batches
-    bool has_valid_batch = false;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
-      has_valid_batch = true;
+    auto load_loop_q_body = [&]() {
       m_block_min = block_meta.inner_block_min;
       m_block_max = block_meta.inner_block_max;
       rebind_Q_tiles(block_meta.seqlen_info);
@@ -1064,6 +1057,25 @@ struct CollectiveMainloopBwdSm90 {
         // Epilogue: load last m block of dO,dPsum
         load_dO_dPsum(m_block_max - 1, bidh_kv_cat);
       }
+    };
+
+    // MainLoop: load Q,dO,LSE,dPsum across m_blocks, with while(true) for RangeMerge batch iteration
+    // K/V are loaded once (fixed n_block), Q/dO are streamed across merged batches
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      load_loop_q_body();
+      if constexpr (Q_dO_same_stages) {
+        smem_pipe_write_do = smem_pipe_write_q;
+      }
+      return true;
+    }
+
+    bool has_valid_batch = false;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        break;
+      has_valid_batch = true;
+      load_loop_q_body();
       block_meta.prefetch();
     }
 
@@ -2184,32 +2196,7 @@ struct CollectiveMainloopBwdSm90 {
     // Main m_block loop with while(true) for RangeMerge batch iteration
     // dK/dV accumulate across all merged batches (fixed n_block)
     // dQ is per-m_block and stored/atomicAdded per iteration
-    bool has_valid_batch = false;
-    if constexpr (BlockMetaT::NeedsBatchLoop) {
-      while (true) {
-        block_meta.skip_to_first_valid();
-        if (block_meta.is_finish())
-          break;
-        has_valid_batch = true;
-        m_block_min = block_meta.inner_block_min;
-        m_block_max = block_meta.inner_block_max;
-        seqlen_q_logical = block_meta.seqlen_info.seqlen_q;
-        seqlen_q = !PackGQA ? seqlen_q_logical : seqlen_q_logical * QheadPerKhead;
-        seqlen_k = block_meta.seqlen_info.seqlen_k;
-        attn_type = block_meta.attn_type;
-        rebind_dQ_accum_tiles();
-
-        for (int bidh_kv_cat = 0; bidh_kv_cat < cute::conditional_return<!CatGQA>(1, QheadPerKhead); ++bidh_kv_cat) {
-          CUTLASS_PRAGMA_NO_UNROLL
-          for (int m_block = m_block_min; m_block < m_block_max - 1; ++m_block) {
-            bwd_step(m_block, mask_fn, /*check_mask_lse_type=*/cute::false_type{});
-          }
-          bwd_step(m_block_max - 1, mask_fn, /*check_mask_lse_type=*/cute::true_type{});
-        }
-        block_meta.prefetch();
-      }
-    } else {
-      has_valid_batch = true;
+    auto mma_loop_q_body = [&]() {
       m_block_min = block_meta.inner_block_min;
       m_block_max = block_meta.inner_block_max;
       seqlen_q_logical = block_meta.seqlen_info.seqlen_q;
@@ -2225,6 +2212,24 @@ struct CollectiveMainloopBwdSm90 {
         }
         bwd_step(m_block_max - 1, mask_fn, /*check_mask_lse_type=*/cute::true_type{});
       }
+    };
+
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      mma_loop_q_body();
+      if constexpr (Q_dO_same_stages) {
+        smem_pipe_read_do = smem_pipe_read_q;
+      }
+      return true;
+    }
+
+    bool has_valid_batch = false;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        break;
+      has_valid_batch = true;
+      mma_loop_q_body();
+      block_meta.prefetch();
     }
 
     if constexpr (Q_dO_same_stages) {
@@ -2917,23 +2922,24 @@ struct CollectiveMainloopBwdSm90 {
           bwd_step(n_block, mask_fn, /*check_mask_lse_type=*/cute::false_type{});
       }
     };
-    bool has_valid_batch = false;
-    if constexpr (BlockMetaT::NeedsBatchLoop) {
-      while (true) {
-        block_meta.skip_to_first_valid();
-        if (block_meta.is_finish())
-          break;
-        if (!has_valid_batch) {
-          wait_QdO_and_copy_LSE_dPsum();
-          has_valid_batch = true;
-        }
-        mma_loop_k_body();
-        block_meta.prefetch();
-      }
-    } else {
+
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
       wait_QdO_and_copy_LSE_dPsum();
       mma_loop_k_body();
-      has_valid_batch = true;
+      return true;
+    }
+
+    bool has_valid_batch = false;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        break;
+      if (!has_valid_batch) {
+        wait_QdO_and_copy_LSE_dPsum();
+        has_valid_batch = true;
+      }
+      mma_loop_k_body();
+      block_meta.prefetch();
     }
 
     return has_valid_batch;

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -1055,6 +1055,9 @@ struct CollectiveMainloopBwdSm90 {
     // MainLoop: load Q,dO,LSE,dPsum across m_blocks, with while(true) for RangeMerge batch iteration
     // K/V are loaded once (fixed n_block), Q/dO are streamed across merged batches
     if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
       load_loop_q_body();
       if constexpr (Q_dO_same_stages) {
         smem_pipe_write_do = smem_pipe_write_q;
@@ -1231,22 +1234,7 @@ struct CollectiveMainloopBwdSm90 {
       copy(bulk_copy.with(barrier_QdO), gdPsum, sdPsum);
     };
 
-    // MainLoop: load K,V left-to-right with pipelined (K_first, then V_i+K_{i+1}).
-    // while(true) iterates over RangeMerge batches; Dense executes exactly once then breaks.
-    // load_QdO_LSE_dPsum() is called once on the first valid batch; subsequent batches only load K/V.
-    // IMPORTANT: skip_to_first_valid() must precede load_QdO_LSE_dPsum() to avoid
-    // barrier signaling on invalid tiles (matches main's early-exit behavior).
-    bool is_first_batch = true;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
-
-      if (is_first_batch) {
-        load_QdO_LSE_dPsum();
-        is_first_batch = false;
-      }
-
+    auto load_loop_k_body = [&]() {
       n_block_min = block_meta.inner_block_min;
       n_block_max = block_meta.inner_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
@@ -1259,7 +1247,31 @@ struct CollectiveMainloopBwdSm90 {
         load_K(n_block + 1, offset_k);
       }
       load_V(n_block, offset_k);
+    };
 
+    // MainLoop: load K,V left-to-right with pipelined (K_first, then V_i+K_{i+1}).
+    // Q/dO/LSE/dPsum are loaded once (fixed m_block), K/V are streamed across merged batches.
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
+      load_QdO_LSE_dPsum();
+      load_loop_k_body();
+      return true;
+    }
+
+    bool is_first_batch = true;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        break;
+
+      if (is_first_batch) {
+        load_QdO_LSE_dPsum();
+        is_first_batch = false;
+      }
+
+      load_loop_k_body();
       block_meta.prefetch();
     }
 
@@ -1491,19 +1503,7 @@ struct CollectiveMainloopBwdSm90 {
       }
     };
 
-    // Main store loop
-    bool is_first_batch = true;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish()) {
-        // Only pass through on first batch (tile entirely invalid from the start).
-        // Subsequent batches have already been fully arrived by the previous iteration.
-        if (is_first_batch) {
-          deterministic_pass_through(0, m_block_num);
-        }
-        return;
-      }
-      is_first_batch = false;
+    auto store_dq_body = [&]() {
       m_block_min = block_meta.inner_block_min;
       m_block_max = block_meta.inner_block_max;
       seqlen_info = block_meta.seqlen_info;
@@ -1526,7 +1526,28 @@ struct CollectiveMainloopBwdSm90 {
       }
 
       deterministic_pass_through(m_block_max, m_block_num);
+    };
 
+    // Main store loop
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      store_dq_body();
+      return;
+    }
+
+    bool is_first_batch = true;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish()) {
+        // Only pass through on first batch (tile entirely invalid from the start).
+        // Subsequent batches have already been fully arrived by the previous iteration.
+        if (is_first_batch) {
+          deterministic_pass_through(0, m_block_num);
+        }
+        return;
+      }
+      is_first_batch = false;
+
+      store_dq_body();
       block_meta.prefetch();
     }
   }
@@ -1607,12 +1628,7 @@ struct CollectiveMainloopBwdSm90 {
       }
     };
 
-    // Iterate across all n_blocks left-to-right (matching load/mma order) for all merged batches.
-    // Dense executes exactly once then breaks.
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        return;
+    auto store_dkv_body = [&]() {
       n_block_min = block_meta.inner_block_min;
       n_block_max = block_meta.inner_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
@@ -1624,7 +1640,22 @@ struct CollectiveMainloopBwdSm90 {
         else if (warp_idx_in_warpgroup == 2)
           store_dk_this_n_block(n_block, offset_k);
       }
+    };
 
+    // Iterate across all n_blocks left-to-right (matching load/mma order) for all merged batches.
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (block_meta.is_valid()) {
+        store_dkv_body();
+      }
+      return;
+    }
+
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        return;
+
+      store_dkv_body();
       block_meta.prefetch();
     }
   }
@@ -2210,6 +2241,9 @@ struct CollectiveMainloopBwdSm90 {
     };
 
     if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
       mma_loop_q_body();
       if constexpr (Q_dO_same_stages) {
         smem_pipe_read_do = smem_pipe_read_q;
@@ -2921,6 +2955,9 @@ struct CollectiveMainloopBwdSm90 {
     };
 
     if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
       wait_QdO_and_copy_LSE_dPsum();
       mma_loop_k_body();
       return true;

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -805,7 +805,7 @@ struct CollectiveMainloopBwdSm90 {
     static_assert(!SwapBwdQKLoop, "load_with_loop_q() must be called when SwapBwdQKLoop is false");
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.outer_block;
+    int const n_block = block_meta.m_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -1038,8 +1038,8 @@ struct CollectiveMainloopBwdSm90 {
       if (block_meta.is_finish())
         break;
       has_valid_batch = true;
-      m_block_min = block_meta.inner_block_min;
-      m_block_max = block_meta.inner_block_max;
+      m_block_min = block_meta.n_block_min;
+      m_block_max = block_meta.n_block_max;
       rebind_Q_tiles(block_meta.seqlen_info);
 
       CUTLASS_PRAGMA_NO_UNROLL
@@ -1085,7 +1085,7 @@ struct CollectiveMainloopBwdSm90 {
     static_assert(!CatGQA, "lood_with_loop_k() is not compatible with CatGQA");
 
     // BlockMeta: fixed per function call
-    int const m_block = block_meta.outer_block;
+    int const m_block = block_meta.m_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -1236,8 +1236,8 @@ struct CollectiveMainloopBwdSm90 {
         is_first_batch = false;
       }
 
-      n_block_min = block_meta.inner_block_min;
-      n_block_max = block_meta.inner_block_max;
+      n_block_min = block_meta.n_block_min;
+      n_block_max = block_meta.n_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
 
       n_block = n_block_min;
@@ -1310,7 +1310,7 @@ struct CollectiveMainloopBwdSm90 {
     static constexpr int kBlockN = CollectiveMainloopBwdSm90::kBlockN;
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.outer_block;
+    int const n_block = block_meta.m_block;
     int const bidh = block_meta.bidh;
     int bidb = block_meta.bidb;
     SeqlenInfo_t seqlen_info = block_meta.seqlen_info;
@@ -1493,8 +1493,8 @@ struct CollectiveMainloopBwdSm90 {
         return;
       }
       is_first_batch = false;
-      m_block_min = block_meta.inner_block_min;
-      m_block_max = block_meta.inner_block_max;
+      m_block_min = block_meta.n_block_min;
+      m_block_max = block_meta.n_block_max;
       seqlen_info = block_meta.seqlen_info;
       bidb = block_meta.bidb;
       attn_type = block_meta.attn_type;
@@ -1602,8 +1602,8 @@ struct CollectiveMainloopBwdSm90 {
       block_meta.skip_to_first_valid();
       if (block_meta.is_finish())
         return;
-      n_block_min = block_meta.inner_block_min;
-      n_block_max = block_meta.inner_block_max;
+      n_block_min = block_meta.n_block_min;
+      n_block_max = block_meta.n_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
 
 #pragma unroll 2
@@ -1675,7 +1675,7 @@ struct CollectiveMainloopBwdSm90 {
     // debug_print_mma();
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.outer_block;
+    int const n_block = block_meta.m_block;
     int const bidh = block_meta.bidh;
     int bidb = block_meta.bidb;
     SeqlenInfo_t seqlen_info = block_meta.seqlen_info;
@@ -2186,8 +2186,8 @@ struct CollectiveMainloopBwdSm90 {
       if (block_meta.is_finish())
         break;
       has_valid_batch = true;
-      m_block_min = block_meta.inner_block_min;
-      m_block_max = block_meta.inner_block_max;
+      m_block_min = block_meta.n_block_min;
+      m_block_max = block_meta.n_block_max;
       seqlen_q_logical = block_meta.seqlen_info.seqlen_q;
       seqlen_q = !PackGQA ? seqlen_q_logical : seqlen_q_logical * QheadPerKhead;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
@@ -2234,7 +2234,7 @@ struct CollectiveMainloopBwdSm90 {
     // debug_print_mma();
 
     // BlockMeta: fixed per function call
-    int const m_block = block_meta.outer_block;
+    int const m_block = block_meta.m_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -2891,8 +2891,8 @@ struct CollectiveMainloopBwdSm90 {
         is_first_batch = false;
       }
 
-      n_block_min = block_meta.inner_block_min;
-      n_block_max = block_meta.inner_block_max;
+      n_block_min = block_meta.n_block_min;
+      n_block_max = block_meta.n_block_max;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
       attn_type = block_meta.attn_type;
       rebind_dKV_accum_tiles();

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -805,7 +805,7 @@ struct CollectiveMainloopBwdSm90 {
     static_assert(!SwapBwdQKLoop, "load_with_loop_q() must be called when SwapBwdQKLoop is false");
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.m_block;
+    int const n_block = block_meta.outer_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -1038,8 +1038,8 @@ struct CollectiveMainloopBwdSm90 {
       if (block_meta.is_finish())
         break;
       has_valid_batch = true;
-      m_block_min = block_meta.n_block_min;
-      m_block_max = block_meta.n_block_max;
+      m_block_min = block_meta.inner_block_min;
+      m_block_max = block_meta.inner_block_max;
       rebind_Q_tiles(block_meta.seqlen_info);
 
       CUTLASS_PRAGMA_NO_UNROLL
@@ -1085,7 +1085,7 @@ struct CollectiveMainloopBwdSm90 {
     static_assert(!CatGQA, "lood_with_loop_k() is not compatible with CatGQA");
 
     // BlockMeta: fixed per function call
-    int const m_block = block_meta.m_block;
+    int const m_block = block_meta.outer_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -1236,8 +1236,8 @@ struct CollectiveMainloopBwdSm90 {
         is_first_batch = false;
       }
 
-      n_block_min = block_meta.n_block_min;
-      n_block_max = block_meta.n_block_max;
+      n_block_min = block_meta.inner_block_min;
+      n_block_max = block_meta.inner_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
 
       n_block = n_block_min;
@@ -1310,7 +1310,7 @@ struct CollectiveMainloopBwdSm90 {
     static constexpr int kBlockN = CollectiveMainloopBwdSm90::kBlockN;
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.m_block;
+    int const n_block = block_meta.outer_block;
     int const bidh = block_meta.bidh;
     int bidb = block_meta.bidb;
     SeqlenInfo_t seqlen_info = block_meta.seqlen_info;
@@ -1493,8 +1493,8 @@ struct CollectiveMainloopBwdSm90 {
         return;
       }
       is_first_batch = false;
-      m_block_min = block_meta.n_block_min;
-      m_block_max = block_meta.n_block_max;
+      m_block_min = block_meta.inner_block_min;
+      m_block_max = block_meta.inner_block_max;
       seqlen_info = block_meta.seqlen_info;
       bidb = block_meta.bidb;
       attn_type = block_meta.attn_type;
@@ -1602,8 +1602,8 @@ struct CollectiveMainloopBwdSm90 {
       block_meta.skip_to_first_valid();
       if (block_meta.is_finish())
         return;
-      n_block_min = block_meta.n_block_min;
-      n_block_max = block_meta.n_block_max;
+      n_block_min = block_meta.inner_block_min;
+      n_block_max = block_meta.inner_block_max;
       offset_k = block_meta.seqlen_info.offset_k;
 
 #pragma unroll 2
@@ -1675,7 +1675,7 @@ struct CollectiveMainloopBwdSm90 {
     // debug_print_mma();
 
     // BlockMeta: fixed per function call
-    int const n_block = block_meta.m_block;
+    int const n_block = block_meta.outer_block;
     int const bidh = block_meta.bidh;
     int bidb = block_meta.bidb;
     SeqlenInfo_t seqlen_info = block_meta.seqlen_info;
@@ -2186,8 +2186,8 @@ struct CollectiveMainloopBwdSm90 {
       if (block_meta.is_finish())
         break;
       has_valid_batch = true;
-      m_block_min = block_meta.n_block_min;
-      m_block_max = block_meta.n_block_max;
+      m_block_min = block_meta.inner_block_min;
+      m_block_max = block_meta.inner_block_max;
       seqlen_q_logical = block_meta.seqlen_info.seqlen_q;
       seqlen_q = !PackGQA ? seqlen_q_logical : seqlen_q_logical * QheadPerKhead;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
@@ -2234,7 +2234,7 @@ struct CollectiveMainloopBwdSm90 {
     // debug_print_mma();
 
     // BlockMeta: fixed per function call
-    int const m_block = block_meta.m_block;
+    int const m_block = block_meta.outer_block;
     int const bidh = block_meta.bidh;
     int const bidh_kv = block_meta.bidh_kv;
     int bidb = block_meta.bidb;
@@ -2891,8 +2891,8 @@ struct CollectiveMainloopBwdSm90 {
         is_first_batch = false;
       }
 
-      n_block_min = block_meta.n_block_min;
-      n_block_max = block_meta.n_block_max;
+      n_block_min = block_meta.inner_block_min;
+      n_block_max = block_meta.inner_block_max;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
       attn_type = block_meta.attn_type;
       rebind_dKV_accum_tiles();

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -774,7 +774,14 @@ struct CollectiveMainloopBwdSm90 {
   //   SwapBwdQKLoop=false → inner loop over m_block (LoopQ) → InnerLoopQ=true
   // So: InnerLoopQ = !SwapBwdQKLoop
   template <bool IsProducer>
-  using BlockMeta = flash::DenseBlockMeta<IsProducer, /*InnerLoopQ=*/!SwapBwdQKLoop, RangeMerge, /*FlattenGQA=*/FlattenGQA, QheadPerKhead, SeqlenInfo_t, BlockMN_t>;
+  using BlockMeta = flash::DenseBlockMeta<
+      IsProducer,
+      /*InnerLoopQ=*/!SwapBwdQKLoop,
+      RangeMerge,
+      /*FlattenGQA=*/FlattenGQA,
+      QheadPerKhead,
+      SeqlenInfo_t,
+      BlockMN_t>;
 
   // Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
   CUTLASS_DEVICE
@@ -1057,7 +1064,6 @@ struct CollectiveMainloopBwdSm90 {
         // Epilogue: load last m block of dO,dPsum
         load_dO_dPsum(m_block_max - 1, bidh_kv_cat);
       }
-
       block_meta.prefetch();
     }
 
@@ -1248,7 +1254,6 @@ struct CollectiveMainloopBwdSm90 {
         load_K(n_block + 1, offset_k);
       }
       load_V(n_block, offset_k);
-
       block_meta.prefetch();
     }
 
@@ -1515,7 +1520,6 @@ struct CollectiveMainloopBwdSm90 {
       }
 
       deterministic_pass_through(m_block_max, m_block_num);
-
       block_meta.prefetch();
     }
   }
@@ -2181,10 +2185,30 @@ struct CollectiveMainloopBwdSm90 {
     // dK/dV accumulate across all merged batches (fixed n_block)
     // dQ is per-m_block and stored/atomicAdded per iteration
     bool has_valid_batch = false;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
+    if constexpr (BlockMetaT::NeedsBatchLoop) {
+      while (true) {
+        block_meta.skip_to_first_valid();
+        if (block_meta.is_finish())
+          break;
+        has_valid_batch = true;
+        m_block_min = block_meta.inner_block_min;
+        m_block_max = block_meta.inner_block_max;
+        seqlen_q_logical = block_meta.seqlen_info.seqlen_q;
+        seqlen_q = !PackGQA ? seqlen_q_logical : seqlen_q_logical * QheadPerKhead;
+        seqlen_k = block_meta.seqlen_info.seqlen_k;
+        attn_type = block_meta.attn_type;
+        rebind_dQ_accum_tiles();
+
+        for (int bidh_kv_cat = 0; bidh_kv_cat < cute::conditional_return<!CatGQA>(1, QheadPerKhead); ++bidh_kv_cat) {
+          CUTLASS_PRAGMA_NO_UNROLL
+          for (int m_block = m_block_min; m_block < m_block_max - 1; ++m_block) {
+            bwd_step(m_block, mask_fn, /*check_mask_lse_type=*/cute::false_type{});
+          }
+          bwd_step(m_block_max - 1, mask_fn, /*check_mask_lse_type=*/cute::true_type{});
+        }
+        block_meta.prefetch();
+      }
+    } else {
       has_valid_batch = true;
       m_block_min = block_meta.inner_block_min;
       m_block_max = block_meta.inner_block_max;
@@ -2201,8 +2225,6 @@ struct CollectiveMainloopBwdSm90 {
         }
         bwd_step(m_block_max - 1, mask_fn, /*check_mask_lse_type=*/cute::true_type{});
       }
-
-      block_meta.prefetch();
     }
 
     if constexpr (Q_dO_same_stages) {
@@ -2880,25 +2902,13 @@ struct CollectiveMainloopBwdSm90 {
     // Main n_block loop: left-to-right, matching load_with_loop_k's L->R pipeline order.
     // while(true) iterates over RangeMerge batches; Dense executes exactly once then breaks.
     // wait_QdO_and_copy_LSE_dPsum is called once on the first valid batch.
-    bool is_first_batch = true;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
-
-      if (is_first_batch) {
-        wait_QdO_and_copy_LSE_dPsum();
-        is_first_batch = false;
-      }
-
+    auto mma_loop_k_body = [&]() {
       n_block_min = block_meta.inner_block_min;
       n_block_max = block_meta.inner_block_max;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
       attn_type = block_meta.attn_type;
       rebind_dKV_accum_tiles();
 
-      // check_mask_lse guards OOB LSE reads at the last m_block of each batch.
-      // Passed as compile-time true_type/false_type so the compiler can elide the check entirely.
       CUTLASS_PRAGMA_NO_UNROLL
       for (int n_block = n_block_min; n_block < n_block_max; ++n_block) {
         if (is_last_m_block_this_batch)
@@ -2906,11 +2916,27 @@ struct CollectiveMainloopBwdSm90 {
         else
           bwd_step(n_block, mask_fn, /*check_mask_lse_type=*/cute::false_type{});
       }
-
-      block_meta.prefetch();
+    };
+    bool has_valid_batch = false;
+    if constexpr (BlockMetaT::NeedsBatchLoop) {
+      while (true) {
+        block_meta.skip_to_first_valid();
+        if (block_meta.is_finish())
+          break;
+        if (!has_valid_batch) {
+          wait_QdO_and_copy_LSE_dPsum();
+          has_valid_batch = true;
+        }
+        mma_loop_k_body();
+        block_meta.prefetch();
+      }
+    } else {
+      wait_QdO_and_copy_LSE_dPsum();
+      mma_loop_k_body();
+      has_valid_batch = true;
     }
 
-    return !is_first_batch;
+    return has_valid_batch;
   }
 
   // Debug print some crucial configuration about mma

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -774,14 +774,7 @@ struct CollectiveMainloopBwdSm90 {
   //   SwapBwdQKLoop=false → inner loop over m_block (LoopQ) → InnerLoopQ=true
   // So: InnerLoopQ = !SwapBwdQKLoop
   template <bool IsProducer>
-  using BlockMeta = flash::DenseBlockMeta<
-      IsProducer,
-      /*InnerLoopQ=*/!SwapBwdQKLoop,
-      RangeMerge,
-      /*FlattenGQA=*/FlattenGQA,
-      QheadPerKhead,
-      SeqlenInfo_t,
-      BlockMN_t>;
+  using BlockMeta = flash::DenseBlockMeta<IsProducer, /*InnerLoopQ=*/!SwapBwdQKLoop, RangeMerge, /*FlattenGQA=*/FlattenGQA, QheadPerKhead, SeqlenInfo_t, BlockMN_t>;
 
   // Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
   CUTLASS_DEVICE
@@ -1266,6 +1259,7 @@ struct CollectiveMainloopBwdSm90 {
         load_K(n_block + 1, offset_k);
       }
       load_V(n_block, offset_k);
+
       block_meta.prefetch();
     }
 
@@ -1532,6 +1526,7 @@ struct CollectiveMainloopBwdSm90 {
       }
 
       deterministic_pass_through(m_block_max, m_block_num);
+
       block_meta.prefetch();
     }
   }
@@ -2914,6 +2909,8 @@ struct CollectiveMainloopBwdSm90 {
       attn_type = block_meta.attn_type;
       rebind_dKV_accum_tiles();
 
+      // check_mask_lse guards OOB LSE reads at the last m_block of each batch.
+      // Passed as compile-time true_type/false_type so the compiler can elide the check entirely.
       CUTLASS_PRAGMA_NO_UNROLL
       for (int n_block = n_block_min; n_block < n_block_max; ++n_block) {
         if (is_last_m_block_this_batch)

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -736,7 +736,7 @@ struct CollectiveMainloopFwdSm90 {
         }
 
         // Prefetch advances cur_loop and updates token_indices/prev_token_indices
-        int n_block_max = block_meta.loop_count;
+        int n_block_max = block_meta.inner_block_max;
         while (true) {
           block_meta.prefetch();
           int n_block = block_meta.cur_loop;

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -761,21 +761,7 @@ struct CollectiveMainloopFwdSm90 {
     int n_block, n_block_min, offset_k;
     int prev_n_block, prev_offset_k;
 
-    bool is_first_batch = true;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
-
-      if (is_first_batch) {
-        load_Q_and_wait_barrier_O();
-        is_first_batch = false;
-      } else if constexpr (IntraWGOverlap) {
-        // Cross-batch V: the previous batch's last V was deferred (IntraWGOverlap
-        // loads V one step behind K). Emit it now before starting new batch's K.
-        load_V(prev_n_block, prev_offset_k);
-      }
-
+    auto load_kv_body = [&]() {
       // Read per-batch variables
       n_block = block_meta.inner_block_max - 1;
       offset_k = block_meta.seqlen_info.offset_k;
@@ -804,7 +790,36 @@ struct CollectiveMainloopFwdSm90 {
         prev_offset_k = offset_k;
         --n_block;
       }
+    };
 
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
+      load_Q_and_wait_barrier_O();
+      load_kv_body();
+      if constexpr (IntraWGOverlap) {
+        load_V(prev_n_block, prev_offset_k);
+      }
+      return true;
+    }
+
+    bool is_first_batch = true;
+    while (true) {
+      block_meta.skip_to_first_valid();
+      if (block_meta.is_finish())
+        break;
+
+      if (is_first_batch) {
+        load_Q_and_wait_barrier_O();
+        is_first_batch = false;
+      } else if constexpr (IntraWGOverlap) {
+        // Cross-batch V: the previous batch's last V was deferred (IntraWGOverlap
+        // loads V one step behind K). Emit it now before starting new batch's K.
+        load_V(prev_n_block, prev_offset_k);
+      }
+
+      load_kv_body();
       block_meta.prefetch();
     }
 
@@ -1205,57 +1220,77 @@ struct CollectiveMainloopFwdSm90 {
       }
     };
 
-    bool is_first_batch = true;
-    while (true) {
-      block_meta.skip_to_first_valid();
-      if (block_meta.is_finish())
-        break;
+    auto mma_dense_body = [&]() {
+      flash::apply_causal_partition<kBlockM, kBlockN>(
+          n_block,
+          n_block_min,
+          block_meta.outer_block,
+          block_meta.seqlen_info.seqlen_q,
+          seqlen_k,
+          attn_type,
+          [&](int nb, auto mask_fn, auto is_no_mask) {
+            using CheckInf = std::conditional_t<decltype(is_no_mask)::value, cute::false_type, cute::true_type>;
+            fwd_step(nb, mask_fn, CheckInf{});
+          },
+          boundary_mask_fn,
+          regular_mask_fn,
+          no_mask_fn);
+    };
 
+    if constexpr (!BlockMetaT::NeedsBatchLoop) {
+      if (!block_meta.is_valid()) {
+        return false;
+      }
       n_block_max = block_meta.inner_block_max;
       n_block = n_block_max - 1;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
       n_block_min = block_meta.inner_block_min;
       attn_type = block_meta.attn_type;
 
-      if (is_first_batch) {
-        barrier_Q.wait(work_idx % 2);
-        mma_head(n_block, attn_type, seqlen_k, /*is_first_ever=*/true);
-        --n_block;
-        is_first_batch = false;
-      }
+      barrier_Q.wait(work_idx % 2);
+      mma_head(n_block, attn_type, seqlen_k, /*is_first_ever=*/true);
+      --n_block;
 
-      if constexpr (SparseLoad || IndexAttn) {
-        while (true) {
-          block_meta.prefetch();
-          if (block_meta.is_finish())
-            break;
-          n_block = n_block_max - 1 - block_meta.cur_loop;
-          if (n_block >= n_block_min) {
-            fwd_step(n_block, no_mask_fn, cute::true_type{} /*check_inf*/);
-          }
+      mma_dense_body();
+    } else {
+      bool is_first_batch = true;
+      while (true) {
+        block_meta.skip_to_first_valid();
+        if (block_meta.is_finish())
+          break;
+
+        n_block_max = block_meta.inner_block_max;
+        n_block = n_block_max - 1;
+        seqlen_k = block_meta.seqlen_info.seqlen_k;
+        n_block_min = block_meta.inner_block_min;
+        attn_type = block_meta.attn_type;
+
+        if (is_first_batch) {
+          barrier_Q.wait(work_idx % 2);
+          mma_head(n_block, attn_type, seqlen_k, /*is_first_ever=*/true);
+          --n_block;
+          is_first_batch = false;
         }
-      } else {
-        flash::apply_causal_partition<kBlockM, kBlockN>(
-            n_block,
-            n_block_min,
-            block_meta.outer_block,
-            block_meta.seqlen_info.seqlen_q,
-            seqlen_k,
-            attn_type,
-            [&](int nb, auto mask_fn, auto is_no_mask) {
-              using CheckInf = std::conditional_t<decltype(is_no_mask)::value, cute::false_type, cute::true_type>;
-              fwd_step(nb, mask_fn, CheckInf{});
-            },
-            boundary_mask_fn,
-            regular_mask_fn,
-            no_mask_fn);
 
-        block_meta.prefetch();
+        if constexpr (SparseLoad || IndexAttn) {
+          while (true) {
+            block_meta.prefetch();
+            if (block_meta.is_finish())
+              break;
+            n_block = n_block_max - 1 - block_meta.cur_loop;
+            if (n_block >= n_block_min) {
+              fwd_step(n_block, no_mask_fn, cute::true_type{} /*check_inf*/);
+            }
+          }
+        } else {
+          mma_dense_body();
+          block_meta.prefetch();
+        }
       }
-    }
 
-    if (is_first_batch) {
-      return false;
+      if (is_first_batch) {
+        return false;
+      }
     }
 
     if constexpr (!SparseLoad && !IndexAttn) {

--- a/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/magi_attention/csrc/flexible_flash_attention/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -555,7 +555,7 @@ struct CollectiveMainloopFwdSm90 {
       }();
 
       Tensor gQ = local_tile(
-          domain_offset(make_coord(block_meta.seqlen_info.offset_q, _0{}), mQ), select<0, 2>(TileShape_MNK{}), make_coord(block_meta.m_block, _0{})); // (M, K)
+          domain_offset(make_coord(block_meta.seqlen_info.offset_q, _0{}), mQ), select<0, 2>(TileShape_MNK{}), make_coord(block_meta.outer_block, _0{})); // (M, K)
       Tensor gQ_Packed = [&]() {
         if constexpr (PackGQA) {
           return local_tile(
@@ -563,7 +563,7 @@ struct CollectiveMainloopFwdSm90 {
                   make_coord(block_meta.seqlen_info.offset_q * QheadPerKhead, _0{}),
                   mQ_Packed), // for packgqa, we need multiple qhead_per_khead for offset of seqlen;
               select<0, 2>(TileShape_MNK{}),
-              make_coord(block_meta.m_block, _0{})); // (M // qhead_per_khead, K, qhead_per_khead)
+              make_coord(block_meta.outer_block, _0{})); // (M // qhead_per_khead, K, qhead_per_khead)
         } else {
           return gQ;
         }
@@ -777,9 +777,9 @@ struct CollectiveMainloopFwdSm90 {
       }
 
       // Read per-batch variables
-      n_block = block_meta.n_block_max - 1;
+      n_block = block_meta.inner_block_max - 1;
       offset_k = block_meta.seqlen_info.offset_k;
-      n_block_min = block_meta.n_block_min;
+      n_block_min = block_meta.inner_block_min;
 
       // Load first K (+ V if !IntraWGOverlap) for this batch
       load_K(n_block, offset_k);
@@ -1050,11 +1050,11 @@ struct CollectiveMainloopFwdSm90 {
 
     // Dense-path mask functions (compiled away when SparseLoad/IndexAttn=true)
     auto boundary_mask_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) {
-      mask.template apply</*Seqlenk_mask=*/true, PackGQA, QheadPerKhead>(tSrS, block_meta.m_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
+      mask.template apply</*Seqlenk_mask=*/true, PackGQA, QheadPerKhead>(tSrS, block_meta.outer_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
     };
     auto no_mask_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) { /*do nothing*/ };
     auto regular_mask_fn = [&](auto& tSrS, int n_block, auto const& attn_type, int const& seqlen_q, int const& seqlen_k) {
-      mask.template apply</*Seqlenk_mask=*/false, PackGQA, QheadPerKhead>(tSrS, block_meta.m_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
+      mask.template apply</*Seqlenk_mask=*/false, PackGQA, QheadPerKhead>(tSrS, block_meta.outer_block, n_block, attn_type, thread_idx, seqlen_q, seqlen_k);
     };
 
     int n_block_max, n_block, seqlen_k, n_block_min;
@@ -1211,10 +1211,10 @@ struct CollectiveMainloopFwdSm90 {
       if (block_meta.is_finish())
         break;
 
-      n_block_max = block_meta.n_block_max;
+      n_block_max = block_meta.inner_block_max;
       n_block = n_block_max - 1;
       seqlen_k = block_meta.seqlen_info.seqlen_k;
-      n_block_min = block_meta.n_block_min;
+      n_block_min = block_meta.inner_block_min;
       attn_type = block_meta.attn_type;
 
       if (is_first_batch) {
@@ -1238,7 +1238,7 @@ struct CollectiveMainloopFwdSm90 {
         flash::apply_causal_partition<kBlockM, kBlockN>(
             n_block,
             n_block_min,
-            block_meta.m_block,
+            block_meta.outer_block,
             block_meta.seqlen_info.seqlen_q,
             seqlen_k,
             attn_type,


### PR DESCRIPTION
## Summary

#317 的 BlockMeta 重构引入了 FWD/BWD 的性能退化。根因是 `DenseBlockMeta` 改为引用成员后导致栈溢出（stack spill），以及 BWD dense path 的控制流未适配新结构。

本 PR 通过 6 个增量 commit 逐步修复，核心改动：
- 消除 `DenseBlockMeta` 中的引用成员，改为值拷贝，避免栈溢出
- 在没有 `RangeMerge` 时 展平 batch-loop 控制流，减少分支开销

## Benchmark（3-run avg, GPU H100, bf16, nhq=48, nhk=8, d=128）

### FWD (TFLOPS)

| seqlen | before-refactor (`7b029b3`) | after-refactor (`64b2c19`) | **this PR (`54211c7`)** | after vs before | **PR vs before** |
|--------|:--:|:--:|:--:|:--:|:--:|
| 2048 | 391.96 | 360.53 | **392.34** | -8.02% | **+0.10%** |
| 4096 | 505.69 | 460.31 | **499.57** | -8.97% | **-1.21%** |
| 8192 | 612.46 | 568.47 | **615.88** | -7.18% | **+0.56%** |
| 16384 | 663.08 | 618.39 | **665.56** | -6.74% | **+0.37%** |
| **avg** | | | | **-7.73%** | **-0.04%** |

### BWD (TFLOPS)

| seqlen | before-refactor (`7b029b3`) | after-refactor (`64b2c19`) | **this PR (`54211c7`)** | after vs before | **PR vs before** |
|--------|:--:|:--:|:--:|:--:|:--:|
| 2048 | 361.20 | 328.84 | **360.70** | -8.96% | **-0.14%** |
| 4096 | 470.24 | 427.05 | **464.92** | -9.18% | **-1.13%** |
| 8192 | 524.01 | 470.70 | **522.58** | -10.17% | **-0.27%** |
| 16384 | 559.58 | 509.38 | **558.50** | -8.97% | **-0.19%** |
| **avg** | | | | **-9.32%** | **-0.43%** |

> 所有数据基于 3 次运行取平均值，忽略 seqlen=1024。（365daca）

## Test plan

- [x] FWD benchmark 3-run avg vs before-refactor: avg diff < 1%
- [x] BWD benchmark 3-run avg vs before-refactor: avg diff < 1%
- [x] after-refactor 对照组确认退化存在（FWD -7.73%, BWD -9.32%）


## Benchmark-2c641357-260609 

flops: 
    seqlen         ffa
0   2048.0  424.627664
1   4096.0  544.747033
2   8192.0  624.582435
3  16384.0  656.673659

flops: 
    seqlen         ffa
0   2048.0  384.513746
1   4096.0  475.292730
2   8192.0  525.115964
3  16384.0  547.264969