### PR TITLE
refactor: IndexAttn indices use logical token positions instead of physical row IDs

### DIFF
--- a/exps/attn/example_index_attn_viewtrick.py
+++ b/exps/attn/example_index_attn_viewtrick.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2025-2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+IndexAttn + PackGQA + View Trick correctness verification
+==========================================================
+
+Background:
+  GQA4 model: NHQ=32, NHK=4, HD=128
+  Want q_block_size=4 speedup, but IndexAttn requires q_block_size=1.
+  Solution: View Trick -- fold consecutive 4 Q tokens into the head dim.
+
+View Trick transform:
+  +---------------------------------------------------------------------+
+  |  Original: q = [S, 32, D]     k = [S, 4, D]       v = [S, 4, D]    |
+  |                                                                      |
+  |  Step 1: Flatten KV heads -- each head becomes an independent row    |
+  |    k_flat = k.view(S*4, 1, D)    v_flat = v.view(S*4, 1, D)         |
+  |                                                                      |
+  |  Step 2: Q fold (QBS=4 tokens -> 128 heads)                         |
+  |    q_viewed = q.view(S//4, 32*4, D) = [S//4, 128, D]                |
+  |                                                                      |
+  |  Result: NHQ_eff=128, NHK_eff=1 -> MQA, use pack_gqa=True           |
+  +---------------------------------------------------------------------+
+
+Indices encoding:
+  indices shape: (S_new, NHK_eff=1, max_topk), dtype=int32
+  Each value is a logical token position: batch_idx * S_kv + token_idx
+  Invalid slots filled with -1, max_topk must be a multiple of tile_size(128)
+
+Run:
+  CUDA_HOME=/usr/local/cuda-13.0 python example_index_attn_viewtrick.py
+"""
+
+import torch
+
+from magi_attention.functional import flex_flash_attn_func
+from magi_attention.utils.sparse_utils import (
+    build_index_attn_indices,
+    get_sdpa_mask_from_index_attn_indices,
+)
+
+# ========================================================
+# Parameters
+# ========================================================
+
+NHQ_ORIG = 32  # original Q heads
+NHK_ORIG = 4  # original KV heads (GQA ratio = 32/4 = 8)
+HD = 128  # head dim
+QBS = 4  # q_block_size: how many Q tokens to fold
+
+# After view trick
+NHQ_EFF = NHQ_ORIG * QBS  # 128
+NHK_EFF = 1  # each original KV head becomes an independent row -> MQA
+
+TILE_SIZE = 128  # IndexAttn kernel tile, max_topk must be a multiple of this
+B = 1
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+SEED = 42
+
+
+# ========================================================
+# FFA forward + backward
+# ========================================================
+
+
+def run_ffa(q_orig, k_orig, v_orig, indices, S_new, grad_output):
+    """Run FFA IndexAttn FWD+BWD, return (out, dq, dk, dv)."""
+    S_kv_flat = k_orig.numel() // HD
+    q_viewed = q_orig.reshape(B * S_new, NHQ_EFF, HD)
+    k_flat = k_orig.reshape(B * S_kv_flat, NHK_EFF, HD)
+    v_flat = v_orig.reshape(B * S_kv_flat, NHK_EFF, HD)
+
+    q = q_viewed.detach().clone().requires_grad_(True)
+    k = k_flat.detach().clone().requires_grad_(True)
+    v = v_flat.detach().clone().requires_grad_(True)
+
+    out, _ = flex_flash_attn_func(
+        q,
+        k,
+        v,
+        index_attn_indices=indices,
+        q_block_size=1,
+        k_block_size=1,
+        pack_gqa=True,
+    )
+    out.backward(grad_output)
+
+    return out, q.grad, k.grad, v.grad
+
+
+# ========================================================
+# SDPA reference forward + backward
+# ========================================================
+
+
+def run_sdpa_ref(q_orig, k_orig, v_orig, indices, S_new, grad_output):
+    """Run PyTorch SDPA FWD+BWD as reference, return (out, dq, dk, dv)."""
+    S_kv_flat = k_orig.numel() // HD
+    q_viewed = q_orig.reshape(B * S_new, NHQ_EFF, HD)
+    k_flat = k_orig.reshape(B * S_kv_flat, NHK_EFF, HD)
+    v_flat = v_orig.reshape(B * S_kv_flat, NHK_EFF, HD)
+
+    # indices -> dense bool mask [B, NHQ_EFF, S_new, S_kv_flat]
+    mask = get_sdpa_mask_from_index_attn_indices(
+        indices,
+        B=B,
+        NHQ=NHQ_EFF,
+        NHK=NHK_EFF,
+        S_q=S_new,
+        S_kv=S_kv_flat,
+        device=DEVICE,
+    )
+
+    # SDPA expects (B, H, S, D) layout
+    q = (
+        q_viewed.reshape(B, S_new, NHQ_EFF, HD)
+        .transpose(1, 2)
+        .detach()
+        .clone()
+        .requires_grad_(True)
+    )
+    k = (
+        k_flat.reshape(B, S_kv_flat, NHK_EFF, HD)
+        .transpose(1, 2)
+        .detach()
+        .clone()
+        .requires_grad_(True)
+    )
+    v = (
+        v_flat.reshape(B, S_kv_flat, NHK_EFF, HD)
+        .transpose(1, 2)
+        .detach()
+        .clone()
+        .requires_grad_(True)
+    )
+
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q,
+        k.expand(B, NHQ_EFF, S_kv_flat, HD),
+        v.expand(B, NHQ_EFF, S_kv_flat, HD),
+        attn_mask=mask,
+    )
+    out.backward(grad_output.reshape(B, S_new, NHQ_EFF, HD).transpose(1, 2))
+
+    return out, q.grad, k.grad, v.grad
+
+
+# ========================================================
+# Compare
+# ========================================================
+
+
+def compare(ffa_results, ref_results, S_new, S_kv_flat):
+    """Compare FFA vs SDPA results, assert cosine similarity."""
+    out_ffa, dq_ffa, dk_ffa, dv_ffa = ffa_results
+    out_ref, dq_ref, dk_ref, dv_ref = ref_results
+
+    def cos(a, b):
+        return torch.nn.functional.cosine_similarity(
+            a.flatten().float(), b.flatten().float(), dim=0
+        ).item()
+
+    # FFA output: (S_new, NHQ_EFF, HD) -> (B, NHQ_EFF, S_new, HD)
+    cos_fwd = cos(out_ffa.reshape(B, S_new, NHQ_EFF, HD).transpose(1, 2), out_ref)
+    cos_dq = cos(dq_ffa.reshape(B, S_new, NHQ_EFF, HD).transpose(1, 2), dq_ref)
+    cos_dk = cos(dk_ffa.reshape(B, S_kv_flat, NHK_EFF, HD).transpose(1, 2), dk_ref)
+    cos_dv = cos(dv_ffa.reshape(B, S_kv_flat, NHK_EFF, HD).transpose(1, 2), dv_ref)
+
+    print(
+        f"  FWD cos={cos_fwd:.6f}  BWD dQ={cos_dq:.6f} dK={cos_dk:.6f} dV={cos_dv:.6f}"
+    )
+    assert cos_fwd > 0.999 and cos_dq > 0.99 and cos_dk > 0.99 and cos_dv > 0.99
+
+
+# ========================================================
+# Test entry
+# ========================================================
+
+
+def run_test(S_orig: int, real_topk: int):
+    S_new = S_orig // QBS
+    S_kv_flat = S_orig * NHK_ORIG
+    max_topk = ((real_topk + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+    print(
+        f"S_orig={S_orig} -> S_new={S_new}, NHQ={NHQ_ORIG}->{NHQ_EFF}, "
+        f"real_topk={real_topk}, max_topk={max_topk} (pad {max_topk - real_topk})"
+    )
+
+    torch.manual_seed(SEED)
+    q_orig = torch.randn(B, S_orig, NHQ_ORIG, HD, device=DEVICE, dtype=DTYPE)
+    k_orig = torch.randn(B, S_orig, NHK_ORIG, HD, device=DEVICE, dtype=DTYPE)
+    v_orig = torch.randn(B, S_orig, NHK_ORIG, HD, device=DEVICE, dtype=DTYPE)
+
+    indices = build_index_attn_indices(
+        B=B,
+        NHK=NHK_EFF,
+        S_q=S_new,
+        S_kv=S_kv_flat,
+        topk=real_topk,
+        max_topk=max_topk,
+        device=DEVICE,
+    )
+    if max_topk > real_topk:
+        assert (indices[:, :, real_topk:] == -1).all(), "Padding should be all -1"
+
+    # Same grad_output for both paths to ensure fair comparison
+    grad_output = torch.randn(B * S_new, NHQ_EFF, HD, device=DEVICE, dtype=DTYPE)
+
+    out_ffa, dq_ffa, dk_ffa, dv_ffa = run_ffa(
+        q_orig, k_orig, v_orig, indices, S_new, grad_output
+    )
+    out_ref, dq_ref, dk_ref, dv_ref = run_sdpa_ref(
+        q_orig, k_orig, v_orig, indices, S_new, grad_output
+    )
+
+    compare(
+        (out_ffa, dq_ffa, dk_ffa, dv_ffa),
+        (out_ref, dq_ref, dk_ref, dv_ref),
+        S_new,
+        S_kv_flat,
+    )
+
+
+if __name__ == "__main__":
+    # Case 1: topk aligned (no padding)
+    run_test(S_orig=1024, real_topk=2048)
+    # Case 2: topk unaligned, pad with -1
+    run_test(S_orig=1024, real_topk=1500)
+    # Case 3: both S_orig and topk unaligned
+    run_test(S_orig=2048, real_topk=1337)
+    print("All tests passed!")

--- a/magi_attention/csrc/flexible_flash_attention/block_meta.h
+++ b/magi_attention/csrc/flexible_flash_attention/block_meta.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <cute/tensor.hpp>
 #include <cutlass/cutlass.h>
 
@@ -453,6 +455,25 @@ struct SparseLoadBlockMeta {
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helper: extract NHK from mainloop params.
+// FWD has shape_K = (seqlen, headdim, nhk); BWD has shape_KVdKdV with same layout.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace detail {
+template <typename P, typename = void>
+struct nhk_of {
+  CUTLASS_DEVICE static int get(P const& p) {
+    return cute::get<2>(p.shape_KVdKdV);
+  }
+};
+template <typename P>
+struct nhk_of<P, std::void_t<decltype(std::declval<P>().shape_K)>> {
+  CUTLASS_DEVICE static int get(P const& p) {
+    return cute::get<2>(p.shape_K);
+  }
+};
+} // namespace detail
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 // IndexAttnBlockMeta: Sparse block metadata for index-based attention.
 // Producer-only arrays (token_indices, prev_token_indices, group_token_ptr)
 // are zero-length when !IsProducer to save registers.
@@ -492,6 +513,9 @@ struct IndexAttnBlockMeta {
   static constexpr int inner_block_min = 0;
 
   int const* group_token_ptr;
+  // NHK and kv_head for logical→physical index conversion
+  int nhk;
+  int kv_head_local;
 
   template <typename ParamsT, typename SharedStorage>
   CUTLASS_DEVICE IndexAttnBlockMeta(ParamsT const& params, cute::tuple<int32_t, int32_t, int32_t> const& block_coord, SharedStorage& shared_storage, int thread_idx = 0)
@@ -508,6 +532,10 @@ struct IndexAttnBlockMeta {
     seqlen_info.seqlen_q = 1;
 
     int unique_idx = get<2>(block_coord);
+    // indices store logical token positions; recover physical row in-kernel
+    nhk = detail::nhk_of<ParamsT>::get(params);
+    kv_head_local = unique_idx % nhk;
+
     int max_topk = params.index_attn_max_topk;
     int const* row_ptr = params.index_attn_indices + static_cast<int64_t>(unique_idx) * max_topk;
 
@@ -541,7 +569,8 @@ struct IndexAttnBlockMeta {
         CUTE_UNROLL
         for (int i = 0; i < NumRowsPerGroup_; ++i) {
           int id = group_token_ptr[i];
-          token_indices[i] = (id >= 0) ? id : 0;
+          // logical position → physical row: pos * NHK + kv_head
+          token_indices[i] = (id >= 0) ? id * nhk + kv_head_local : 0;
         }
       }
     }
@@ -569,7 +598,8 @@ struct IndexAttnBlockMeta {
         CUTE_UNROLL
         for (int i = 0; i < NumRowsPerGroup_; ++i) {
           int id = group_token_ptr[i];
-          token_indices[i] = (id >= 0) ? id : 0;
+          // logical position → physical row: pos * NHK + kv_head
+          token_indices[i] = (id >= 0) ? id * nhk + kv_head_local : 0;
         }
       }
     }

--- a/magi_attention/functional/flex_flash_attn.py
+++ b/magi_attention/functional/flex_flash_attn.py
@@ -1205,7 +1205,8 @@ def flex_flash_attn_func(
 
         index_attn_indices (torch.Tensor, optional): IndexAttn token indices.
             Shape: ``(total_q, num_kv_heads, max_topk)``, dtype=int32.
-            Values are **global** KV row indices into the K/V tensors.
+            Values are **logical** KV token positions: ``batch_idx * S_kv + token_idx``.
+            The kernel internally converts to physical row via ``pos * NHK + kv_head``.
             Use ``-1`` for padding (must be contiguous at the tail of each row).
             Mutually exclusive with ``q_ranges``.
             The kernel scans trailing ``-1`` entries to determine loop count and

--- a/magi_attention/utils/sparse_utils.py
+++ b/magi_attention/utils/sparse_utils.py
@@ -541,15 +541,16 @@ def build_index_attn_indices(
     device: str | torch.device = "cuda",
     k_block_size: int = 1,
 ) -> torch.Tensor:
-    """Build random index_attn_indices (total_q, NHK, max_topk) with global KV row ids.
+    """Build random index_attn_indices (total_q, NHK, max_topk) with logical KV token positions.
 
-    For batch b, token t, head h the global row is (b * S_kv + t) * NHK + h.
+    Values are logical token positions: ``b * S_kv + token_idx``.
+    The kernel internally converts to physical row via ``logical_pos * NHK + kv_head``.
 
     Args:
         topk: int or list[int]. If list, per-batch topk (length must be B).
 
     Returns:
-        Tensor of shape (B * S_q, NHK, max_topk) with int32 global row ids (-1 = padding).
+        Tensor of shape (B * S_q, NHK, max_topk) with int32 logical positions (-1 = padding).
     """
     num_kv_blocks = S_kv // k_block_size
     total_q = B * S_q
@@ -566,8 +567,8 @@ def build_index_attn_indices(
         rand_keys = torch.rand(n_rows, num_kv_blocks, device=device)
         _, perm_all = rand_keys.topk(tk, dim=1, largest=False, sorted=True)
         perm_all = perm_all.reshape(S_q, NHK, tk)
-        h_offsets = torch.arange(NHK, device=device).reshape(1, NHK, 1)
-        global_ids = (b_idx * S_kv + perm_all) * NHK + h_offsets
+        # logical token position: batch offset + token index (no head encoding)
+        global_ids = b_idx * S_kv + perm_all
         row_start = b_idx * S_q
         indices[row_start : row_start + S_q, :, :tk] = global_ids.int()
     return indices
@@ -585,8 +586,8 @@ def get_sdpa_mask_from_index_attn_indices(
 ) -> torch.Tensor:
     """Build dense boolean mask [B, NHQ, S_q, S_kv] from index_attn_indices for SDPA ref.
 
-    index_attn_indices: (total_q, NHK, max_topk) with global KV row ids.
-    Global row id = (b * S_kv + local_token) * NHK + h  (b,s,h order).
+    index_attn_indices: (total_q, NHK, max_topk) with logical KV token positions.
+    Logical position = b * S_kv + local_token (no head encoding).
     Vectorized: no Python loops.
     """
     gqa = NHQ // NHK
@@ -597,7 +598,8 @@ def get_sdpa_mask_from_index_attn_indices(
     valid_mask = idx >= 0
 
     b_indices = torch.arange(B, device=device).repeat_interleave(S_q)  # (total_q,)
-    local_ids = idx // NHK - b_indices[:, None, None] * S_kv
+    # logical position → local token: subtract batch offset (no NHK division needed)
+    local_ids = idx - b_indices[:, None, None] * S_kv
 
     if k_block_size == 1:
         kv_col = local_ids

--- a/tests/test_attn/test_simple_attn.py
+++ b/tests/test_attn/test_simple_attn.py
@@ -154,9 +154,12 @@ class TestSimpleAttn(unittest.TestCase):
 
     @parameterize("cfg", INDEX_ATTN_CONFIGS)
     def test_index_attn_simple(self, cfg: dict[str, Any]):
-        """IndexAttn FWD+BWD correctness against SDPA reference."""
-        from einops import rearrange as einops_rearrange
+        """IndexAttn FWD+BWD correctness against SDPA reference.
 
+        The view trick flattens K from (B,S,NHK,D) to (B*S*NHK, 1, D), so
+        the kernel sees NHK_eff=1. Indices must be built in this flat token
+        space (NHK=1, S_flat=S*NHK) with logical positions.
+        """
         from magi_attention.utils import set_random_seed
 
         set_random_seed(42)
@@ -170,32 +173,27 @@ class TestSimpleAttn(unittest.TestCase):
         )
         pack_gqa = cfg["pack_gqa"]
         device = self.device
-        total_q = B * S
 
-        indices = build_index_attn_indices(B, NHK, S, S, topk, topk, device)
+        gqa = NHQ // NHK
+        S_flat = S * NHK
+        NHQ_eff = gqa
+
+        indices = build_index_attn_indices(B, 1, S_flat, S_flat, topk, topk, device)
 
         q_raw = torch.randn(B, S, NHQ, D, dtype=torch.bfloat16, device=device)
         k_raw = torch.randn(B, S, NHK, D, dtype=torch.bfloat16, device=device)
         v_raw = torch.randn(B, S, NHK, D, dtype=torch.bfloat16, device=device)
 
         q_ffa = (
-            einops_rearrange(q_raw, "b s (h1 h2) d -> (b s h1) h2 d", h1=NHK)
+            q_raw.reshape(B, S, NHK, gqa, D)
+            .permute(0, 1, 2, 3, 4)
+            .reshape(B * S * NHK, gqa, D)
             .detach()
             .clone()
             .requires_grad_(True)
         )
-        k_ffa = (
-            einops_rearrange(k_raw, "b s h d -> (b s h) 1 d")
-            .detach()
-            .clone()
-            .requires_grad_(True)
-        )
-        v_ffa = (
-            einops_rearrange(v_raw, "b s h d -> (b s h) 1 d")
-            .detach()
-            .clone()
-            .requires_grad_(True)
-        )
+        k_ffa = k_raw.reshape(B * S * NHK, 1, D).detach().clone().requires_grad_(True)
+        v_ffa = v_raw.reshape(B * S * NHK, 1, D).detach().clone().requires_grad_(True)
 
         o_sparse, _ = flex_flash_attn_func(
             q_ffa,
@@ -207,29 +205,27 @@ class TestSimpleAttn(unittest.TestCase):
             pack_gqa=pack_gqa,
         )
 
-        o_reshaped = einops_rearrange(
-            o_sparse, "(b s h1) h2 d -> b s (h1 h2) d", b=B, h1=NHK, s=S
+        mask = get_sdpa_mask_from_index_attn_indices(
+            indices, B, NHQ_eff, 1, S_flat, S_flat, device
         )
 
-        gqa = NHQ // NHK
-        mask = get_sdpa_mask_from_index_attn_indices(indices, B, NHQ, NHK, S, S, device)
-
-        # FWD verification
+        # FWD verification (compare in flat token space)
         for b in range(B):
-            q_sdpa = einops_rearrange(q_raw[b], "s h d -> 1 h s d")
-            k_sdpa = einops_rearrange(k_raw[b], "s h d -> 1 h s d")
-            v_sdpa = einops_rearrange(v_raw[b], "s h d -> 1 h s d")
-            if gqa > 1:
-                k_sdpa = k_sdpa.repeat_interleave(gqa, dim=1)
-                v_sdpa = v_sdpa.repeat_interleave(gqa, dim=1)
+            sl = slice(b * S_flat, (b + 1) * S_flat)
+            q_b = q_ffa[sl].detach().reshape(1, S_flat, NHQ_eff, D).transpose(1, 2)
+            k_b = k_ffa[sl].detach().reshape(1, S_flat, 1, D).transpose(1, 2)
+            v_b = v_ffa[sl].detach().reshape(1, S_flat, 1, D).transpose(1, 2)
+            if NHQ_eff > 1:
+                k_b = k_b.expand(1, NHQ_eff, S_flat, D)
+                v_b = v_b.expand(1, NHQ_eff, S_flat, D)
 
             with torch.no_grad():
                 o_ref = torch.nn.functional.scaled_dot_product_attention(
-                    q_sdpa, k_sdpa, v_sdpa, attn_mask=mask[b].unsqueeze(0)
+                    q_b, k_b, v_b, attn_mask=mask[b].unsqueeze(0)
                 )
-            o_ref = einops_rearrange(o_ref, "1 h s d -> s h d")
+            o_ref = o_ref.squeeze(0).transpose(0, 1)
 
-            max_diff = (o_reshaped[b].float() - o_ref.float()).abs().max().item()
+            max_diff = (o_sparse[sl].float() - o_ref.float()).abs().max().item()
             assert max_diff < 0.01, (
                 f"[test_index_attn][{cfg['name']}] "
                 f"FWD batch {b}: max_diff={max_diff:.6f} >= 0.01"
@@ -240,57 +236,43 @@ class TestSimpleAttn(unittest.TestCase):
         o_sparse.backward(do)
         dq_ffa = q_ffa.grad.clone()
 
-        dq_ref_list = []
         for b in range(B):
-            q_sdpa = (
-                einops_rearrange(q_raw[b], "s h d -> 1 h s d")
+            sl = slice(b * S_flat, (b + 1) * S_flat)
+            q_b = (
+                q_ffa[sl]
                 .detach()
                 .clone()
+                .reshape(1, S_flat, NHQ_eff, D)
+                .transpose(1, 2)
                 .requires_grad_(True)
             )
-            k_sdpa = (
-                einops_rearrange(k_raw[b], "s h d -> 1 h s d")
+            k_b = (
+                k_ffa[sl]
                 .detach()
                 .clone()
+                .reshape(1, S_flat, 1, D)
+                .transpose(1, 2)
                 .requires_grad_(True)
             )
-            v_sdpa = (
-                einops_rearrange(v_raw[b], "s h d -> 1 h s d")
+            v_b = (
+                v_ffa[sl]
                 .detach()
                 .clone()
+                .reshape(1, S_flat, 1, D)
+                .transpose(1, 2)
                 .requires_grad_(True)
             )
-            if gqa > 1:
-                k_sdpa_exp = k_sdpa.repeat_interleave(gqa, dim=1)
-                v_sdpa_exp = v_sdpa.repeat_interleave(gqa, dim=1)
-            else:
-                k_sdpa_exp = k_sdpa
-                v_sdpa_exp = v_sdpa
+            k_exp = k_b.expand(1, NHQ_eff, S_flat, D) if NHQ_eff > 1 else k_b
+            v_exp = v_b.expand(1, NHQ_eff, S_flat, D) if NHQ_eff > 1 else v_b
 
             o_ref = torch.nn.functional.scaled_dot_product_attention(
-                q_sdpa, k_sdpa_exp, v_sdpa_exp, attn_mask=mask[b].unsqueeze(0)
+                q_b, k_exp, v_exp, attn_mask=mask[b].unsqueeze(0)
             )
-            do_reshaped = einops_rearrange(
-                do, "(b s h1) h2 d -> b 1 (h1 h2) s d", b=B, h1=NHK, s=S
-            )[b]
-            o_ref.backward(do_reshaped)
-            dq_ref_list.append(q_sdpa.grad)
+            do_b = do[sl].reshape(1, S_flat, NHQ_eff, D).transpose(1, 2)
+            o_ref.backward(do_b)
 
-        dq_ref = torch.cat(dq_ref_list, dim=0)
-        dq_ref = einops_rearrange(dq_ref, "b h s d -> (b s) h d", b=B)[:total_q]
-
-        dq_ffa_reshaped = einops_rearrange(
-            dq_ffa, "(b s h1) h2 d -> b (h1 h2) s d", b=B, h1=NHK, s=S
-        )
-        dq_ref_reshaped = einops_rearrange(dq_ref, "(b s) h d -> b h s d", b=B, s=S)
-
-        for b in range(B):
-            max_dq_diff = (
-                (dq_ffa_reshaped[b].float() - dq_ref_reshaped[b].float())
-                .abs()
-                .max()
-                .item()
-            )
+            dq_ref_b = q_b.grad.squeeze(0).transpose(0, 1)
+            max_dq_diff = (dq_ffa[sl].float() - dq_ref_b.float()).abs().max().item()
             assert max_dq_diff < 0.05, (
                 f"[test_index_attn][{cfg['name']}] "
                 f"BWD batch {b}: dQ max_diff={max_dq_diff:.6f} >= 0.05"
@@ -1059,8 +1041,6 @@ class TestSimpleAttn(unittest.TestCase):
         """
         import os
 
-        from einops import rearrange as einops_rearrange
-
         from magi_attention.functional._flex_flash_attn_jit import get_ffa_jit_mod
 
         device = self.device
@@ -1122,12 +1102,14 @@ class TestSimpleAttn(unittest.TestCase):
 
             # ── Part 2: IndexAttn with non-aligned topk (padding block) ──
             B, S, NHQ_ia, NHK_ia, D = 1, 256, 32, 4, 128
-            actual_topk = 100  # not multiple of kBlockN=128 → 28 padding tokens
+            actual_topk = 100
             max_topk = 128
-            gqa = NHQ_ia // NHK_ia
+            gqa_ia = NHQ_ia // NHK_ia
+            S_flat = S * NHK_ia
+            NHQ_eff = gqa_ia
 
             indices = build_index_attn_indices(
-                B, NHK_ia, S, S, actual_topk, max_topk, device
+                B, 1, S_flat, S_flat, actual_topk, max_topk, device
             )
 
             q_raw = torch.randn(B, S, NHQ_ia, D, dtype=dtype, device=device)
@@ -1135,19 +1117,21 @@ class TestSimpleAttn(unittest.TestCase):
             v_raw = torch.randn(B, S, NHK_ia, D, dtype=dtype, device=device)
 
             q_ffa = (
-                einops_rearrange(q_raw, "b s (h1 h2) d -> (b s h1) h2 d", h1=NHK_ia)
+                q_raw.reshape(B, S, NHK_ia, gqa_ia, D)
+                .permute(0, 1, 2, 3, 4)
+                .reshape(B * S * NHK_ia, gqa_ia, D)
                 .detach()
                 .clone()
                 .requires_grad_(True)
             )
             k_ffa = (
-                einops_rearrange(k_raw, "b s h d -> (b s h) 1 d")
+                k_raw.reshape(B * S * NHK_ia, 1, D)
                 .detach()
                 .clone()
                 .requires_grad_(True)
             )
             v_ffa = (
-                einops_rearrange(v_raw, "b s h d -> (b s h) 1 d")
+                v_raw.reshape(B * S * NHK_ia, 1, D)
                 .detach()
                 .clone()
                 .requires_grad_(True)
@@ -1163,28 +1147,24 @@ class TestSimpleAttn(unittest.TestCase):
                 pack_gqa=True,
             )
 
-            o_reshaped = einops_rearrange(
-                o_sparse, "(b s h1) h2 d -> b s (h1 h2) d", b=B, h1=NHK_ia, s=S
-            )
-
-            # Build reference mask from indices
             ref_mask = get_sdpa_mask_from_index_attn_indices(
-                indices, B, NHQ_ia, NHK_ia, S, S, device
+                indices, B, NHQ_eff, 1, S_flat, S_flat, device
             )
 
             for b_i in range(B):
-                q_sdpa = einops_rearrange(q_raw[b_i], "s h d -> 1 h s d")
-                k_sdpa = einops_rearrange(k_raw[b_i], "s h d -> 1 h s d")
-                v_sdpa = einops_rearrange(v_raw[b_i], "s h d -> 1 h s d")
-                if gqa > 1:
-                    k_sdpa = k_sdpa.repeat_interleave(gqa, dim=1)
-                    v_sdpa = v_sdpa.repeat_interleave(gqa, dim=1)
+                sl = slice(b_i * S_flat, (b_i + 1) * S_flat)
+                q_b = q_ffa[sl].detach().reshape(1, S_flat, NHQ_eff, D).transpose(1, 2)
+                k_b = k_ffa[sl].detach().reshape(1, S_flat, 1, D).transpose(1, 2)
+                v_b = v_ffa[sl].detach().reshape(1, S_flat, 1, D).transpose(1, 2)
+                if NHQ_eff > 1:
+                    k_b = k_b.expand(1, NHQ_eff, S_flat, D)
+                    v_b = v_b.expand(1, NHQ_eff, S_flat, D)
                 with torch.no_grad():
                     o_ref = torch.nn.functional.scaled_dot_product_attention(
-                        q_sdpa, k_sdpa, v_sdpa, attn_mask=ref_mask[b_i].unsqueeze(0)
+                        q_b, k_b, v_b, attn_mask=ref_mask[b_i].unsqueeze(0)
                     )
-                o_ref = einops_rearrange(o_ref, "1 h s d -> s h d")
-                max_diff = (o_reshaped[b_i].float() - o_ref.float()).abs().max().item()
+                o_ref = o_ref.squeeze(0).transpose(0, 1)
+                max_diff = (o_sparse[sl].float() - o_ref.float()).abs().max().item()
                 assert max_diff < 0.01, (
                     f"[test_inner_dir_min_to_max/index_attn] "
                     f"FWD batch {b_i}: max_diff={max_diff:.6f} >= 0.01"

--- a/tests/test_attn/test_simple_attn.py
+++ b/tests/test_attn/test_simple_attn.py
@@ -27,6 +27,10 @@ import torch
 from magi_attention.common import AttnRanges
 from magi_attention.functional import flex_flash_attn_func
 from magi_attention.testing import parameterize
+from magi_attention.utils.sparse_utils import (
+    build_index_attn_indices,
+    get_sdpa_mask_from_index_attn_indices,
+)
 
 
 class TestSimpleAttn(unittest.TestCase):
@@ -168,14 +172,7 @@ class TestSimpleAttn(unittest.TestCase):
         device = self.device
         total_q = B * S
 
-        indices = torch.full((total_q, NHK, topk), -1, dtype=torch.int32, device=device)
-        for b in range(B):
-            for qi in range(S):
-                row = b * S + qi
-                for h in range(NHK):
-                    perm = torch.randperm(S, device=device)[:topk].sort().values
-                    global_ids = (b * S + perm) * NHK + h
-                    indices[row, h, :topk] = global_ids.int()
+        indices = build_index_attn_indices(B, NHK, S, S, topk, topk, device)
 
         q_raw = torch.randn(B, S, NHQ, D, dtype=torch.bfloat16, device=device)
         k_raw = torch.randn(B, S, NHK, D, dtype=torch.bfloat16, device=device)
@@ -215,17 +212,7 @@ class TestSimpleAttn(unittest.TestCase):
         )
 
         gqa = NHQ // NHK
-        mask = torch.zeros(B, NHQ, S, S, dtype=torch.bool, device=device)
-        for b in range(B):
-            for qi in range(S):
-                row = b * S + qi
-                for h_kv in range(NHK):
-                    global_ids = indices[row, h_kv, :]
-                    valid = global_ids[global_ids >= 0].long()
-                    local_kv = valid // NHK - b * S
-                    for h_q_off in range(gqa):
-                        h_q = h_kv * gqa + h_q_off
-                        mask[b, h_q, qi, local_kv] = True
+        mask = get_sdpa_mask_from_index_attn_indices(indices, B, NHQ, NHK, S, S, device)
 
         # FWD verification
         for b in range(B):
@@ -1137,21 +1124,11 @@ class TestSimpleAttn(unittest.TestCase):
             B, S, NHQ_ia, NHK_ia, D = 1, 256, 32, 4, 128
             actual_topk = 100  # not multiple of kBlockN=128 → 28 padding tokens
             max_topk = 128
-            total_q_ia = B * S
             gqa = NHQ_ia // NHK_ia
 
-            indices = torch.full(
-                (total_q_ia, NHK_ia, max_topk), -1, dtype=torch.int32, device=device
+            indices = build_index_attn_indices(
+                B, NHK_ia, S, S, actual_topk, max_topk, device
             )
-            for b_i in range(B):
-                for qi in range(S):
-                    row = b_i * S + qi
-                    for h in range(NHK_ia):
-                        perm = (
-                            torch.randperm(S, device=device)[:actual_topk].sort().values
-                        )
-                        global_ids = (b_i * S + perm) * NHK_ia + h
-                        indices[row, h, :actual_topk] = global_ids.int()
 
             q_raw = torch.randn(B, S, NHQ_ia, D, dtype=dtype, device=device)
             k_raw = torch.randn(B, S, NHK_ia, D, dtype=dtype, device=device)
@@ -1190,18 +1167,10 @@ class TestSimpleAttn(unittest.TestCase):
                 o_sparse, "(b s h1) h2 d -> b s (h1 h2) d", b=B, h1=NHK_ia, s=S
             )
 
-            # Build reference
-            ref_mask = torch.zeros(B, NHQ_ia, S, S, dtype=torch.bool, device=device)
-            for b_i in range(B):
-                for qi in range(S):
-                    row = b_i * S + qi
-                    for h_kv in range(NHK_ia):
-                        gids = indices[row, h_kv, :]
-                        valid = gids[gids >= 0].long()
-                        local_kv = valid // NHK_ia - b_i * S
-                        for h_q_off in range(gqa):
-                            h_q = h_kv * gqa + h_q_off
-                            ref_mask[b_i, h_q, qi, local_kv] = True
+            # Build reference mask from indices
+            ref_mask = get_sdpa_mask_from_index_attn_indices(
+                indices, B, NHQ_ia, NHK_ia, S, S, device
+            )
 
             for b_i in range(B):
                 q_sdpa = einops_rearrange(q_raw[b_i], "s h d -> 1 h s d")


### PR DESCRIPTION
## 概述

将 `index_attn_indices` 的语义从**物理 KV 行地址**（`(b*S_kv+token)*NHK+head`）改为**逻辑 token 位置**（`b*S_kv+token`），kernel 内部通过 `pos * NHK + kv_head` 恢复物理行地址。

## 改动点

1. **sparse_utils.py**: `build_index_attn_indices` 生成逻辑位置；`get_sdpa_mask_from_index_attn_indices` 适配新语义
2. **flex_flash_attn.py**: 更新 `index_attn_indices` 参数文档
3. **block_meta.h**: 新增 SFINAE helper `detail::nhk_of`，从 FWD `shape_K` / BWD `shape_KVdKdV` 编译期推导 NHK，无需新增 params 字段；`IndexAttnBlockMeta` 构造和 prefetch 中执行 `id * nhk + kv_head_local` 转换
4. **test_simple_attn.py**: 内联 indices/mask 构建替换为 `build_index_attn_indices` / `get_sdpa_mask_from_index_attn_indices` 调用
5. **exps/attn/example_index_attn_viewtrick.py**: 新增 IndexAttn + PackGQA + View Trick 使用示例

## 收益

- **接口更直觉**: 用户只需传入 token 位置，不再关心底层物理布局
- **GQA 友好**: NHK 变化时 indices 不变，同一份 indices 可复用于不同 GQA 配置
- **零性能回退**: 仅在 IndexAttn 路径增加一次整数乘加，dense 路径完全不受影响

## 使用示例

`exps/attn/example_index_attn_viewtrick.py` 演示了 IndexAttn 在以下场景的完整用法：
- **PackGQA + View Trick**: GQA4（nhq=128, nhk=32）通过 view trick 展平为 MQA-like 128 head 形态
- **q_block_size=4**: 利用 view trick 后自然获得
- **600K seqlen, topk=2048**
- 覆盖 FWD + BWD 正确性验证（对比 SDPA reference）
- 包含 `-1 padding` 处理（topk 非 128 整数倍时的 pad 策略）