### PR TITLE
[HotFix] Upgrade docker base image version

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -79,7 +79,7 @@ jobs:
     environment: ${{ (github.event_name == 'pull_request_target') && 'ci-internal' || '' }}
     runs-on: [self-hosted]
     container:
-      image: registry.cn-sh-01.sensecore.cn/sandai-ccr/magi-base:25.10.5
+      image: registry.cn-sh-01.sensecore.cn/sandai-ccr/magi-base:25.10.10
       options: --gpus all --ipc host
       credentials:
         username: ${{ secrets.DOCKER_USER_NAME }}

--- a/exps/dist_attn/Dockerfile.benchmark
+++ b/exps/dist_attn/Dockerfile.benchmark
@@ -1,4 +1,4 @@
-FROM registry.cn-sh-01.sensecore.cn/sandai-ccr/magi-base:25.10.1
+FROM registry.cn-sh-01.sensecore.cn/sandai-ccr/magi-base:25.10.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## DONE

- upgraded `magi-base` docker image tag to `25.10.10`.