### PR TITLE
feat: support 192/128 and 256/256 ffa_fa4 in magi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/NVIDIA/cutlass.git
 [submodule "magi_attention/functional/flash-attention"]
 	path = magi_attention/functional/flash-attention
-	url = https://github.com/demonatic/flash-attention.git
-	branch = magi_attn_blackwell_support
+	url = https://github.com/jiayus-nvidia/flash-attention.git
+	branch = magi_backend

--- a/magi_attention/api/magi_attn_interface.py
+++ b/magi_attention/api/magi_attn_interface.py
@@ -169,6 +169,7 @@ def magi_attn_varlen_key(
     window_size: tuple[int, int] = (-1, -1),
     dist_attn_config: DistAttnConfig = DistAttnConfig(),
     chunk_size: int | None = None,
+    head_dim_v: int | None = None,
 ) -> DistAttnRuntimeKey:
     """This is a flash-attn-varlen like interface,
     to generate ``q_ranges``, ``k_ranges`` and ``attn_mask_type``
@@ -295,6 +296,7 @@ def magi_attn_varlen_key(
         cp_group_or_mesh=cp_group_or_mesh,
         dist_attn_config=dist_attn_config,
         chunk_size=chunk_size,
+        head_dim_v=head_dim_v,
     )
 
 
@@ -453,6 +455,7 @@ def magi_attn_flex_key(
     is_q_permutable: bool = True,
     is_k_permutable: bool = True,
     chunk_size: int | None = None,
+    head_dim_v: int | None = None,
 ) -> DistAttnRuntimeKey:
     """This is the most flexible interface,
     directly passing in ``q_ranges``, ``k_ranges`` and ``attn_mask_type`` to
@@ -690,6 +693,7 @@ def magi_attn_flex_key(
         cp_group=cp_group,
         cp_mesh=cp_mesh,
         dist_attn_config=dist_attn_config,
+        head_dim_v=head_dim_v,
     )
 
     # Init dist attn runtime mgr and map it to the key
@@ -713,6 +717,7 @@ def magi_attn_flex_key(
             is_same_source=is_same_source,
             is_q_permutable=is_q_permutable,
             is_k_permutable=is_k_permutable,
+            head_dim_v=head_dim_v,
         )
 
     return key

--- a/magi_attention/dist_attn_runtime_mgr.py
+++ b/magi_attention/dist_attn_runtime_mgr.py
@@ -68,6 +68,7 @@ class DistAttnRuntimeKey:
     num_heads_q: int
     num_heads_kv: int
     head_dim: int
+    head_dim_v: int | None
     pad_size: int
     chunk_size: int
     cp_group: dist.ProcessGroup
@@ -99,6 +100,7 @@ class DistAttnRuntimeKey:
                     self.num_heads_q,
                     self.num_heads_kv,
                     self.head_dim,
+                    self.head_dim_v,
                     self.pad_size,
                     self.chunk_size,
                     self.cp_group,
@@ -495,11 +497,21 @@ def init_dist_attn_runtime_key(
     cp_group: dist.ProcessGroup,
     cp_mesh: DeviceMesh | None,
     dist_attn_config: DistAttnConfig,
+    head_dim_v: int | None = None,
 ) -> DistAttnRuntimeKey:
     """Initialize DistAttnRuntimeKey"""
 
     # Check if flag combinations are valid
     check_flag_comb()
+
+    # Canonicalise head_dim_v: symmetric K/V is represented by `None` (the
+    # default), so that cache hits work regardless of whether the caller
+    # passed `head_dim_v=None` (no-op default) or `head_dim_v=head_dim`
+    # (explicit-but-symmetric). Without this, both would produce distinct
+    # DistAttnRuntimeKey hashes for the same logical config and waste LRU
+    # slots.
+    if head_dim_v == head_dim:
+        head_dim_v = None
 
     return DistAttnRuntimeKey(
         q_ranges=q_ranges,
@@ -510,6 +522,7 @@ def init_dist_attn_runtime_key(
         num_heads_q=num_heads_q,
         num_heads_kv=num_heads_kv,
         head_dim=head_dim,
+        head_dim_v=head_dim_v,
         pad_size=pad_size,
         chunk_size=chunk_size,
         cp_group=cp_group,
@@ -560,6 +573,7 @@ def init_dist_attn_runtime_mgr(
     is_k_permutable: bool = True,
     ref_dispatch_meta_q: DispatchMeta | None = None,
     ref_dispatch_meta_k: DispatchMeta | None = None,
+    head_dim_v: int | None = None,
 ) -> DistAttnRuntimeMgr:
     """
 
@@ -648,6 +662,10 @@ def init_dist_attn_runtime_mgr(
     """
 
     uneven_shard: bool = dist_attn_config.dispatch_config.uneven_shard
+
+    # Canonicalise head_dim_v: see `init_dist_attn_runtime_key` for rationale.
+    if head_dim_v == head_dim:
+        head_dim_v = None
 
     cp_size = dist.get_world_size(cp_group)
     cp_rank = dist.get_rank(cp_group)
@@ -855,6 +873,7 @@ def init_dist_attn_runtime_mgr(
         overlap_config=overlap_config,
         cp_group=cp_group,
         cp_mesh=cp_mesh,
+        head_dim_v=head_dim_v,
     )
 
     logger.info(

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -177,8 +177,19 @@ class DistAttnRuntime:
         # cp1 shortcut: skip all communication
         self.skip_comm = cp_group_gc.size() == 1
 
-        # NOTE: concat kv together for comm only when not using native grpcoll and world_size > 1
-        self.concat_kv = (not self.skip_comm) and (not self.use_native_grpcoll)
+        # MLA-style asymmetric K/V (d_qk != d_v) baked into CommMeta. When True,
+        # KV is packed along the head_dim axis (not seqlen), and the symmetric
+        # "fused along seqlen" path (concat_kv=True) is disabled.
+        self.is_asymmetric_kv = comm_meta.is_asymmetric_kv
+
+        # NOTE: concat kv together for comm only when not using native grpcoll
+        # and world_size > 1; force False for asymmetric K/V (the asymmetric
+        # path inside `_fetch_remote_kv` does its own cat-on-head_dim fusion).
+        self.concat_kv = (
+            (not self.skip_comm)
+            and (not self.use_native_grpcoll)
+            and (not self.is_asymmetric_kv)
+        )
 
         # NOTE: only the FFA backend supports accumulative buffer for out/lse
         # to avoid storing partial results and an explicit `correct_attn_out_lse`
@@ -206,8 +217,13 @@ class DistAttnRuntime:
 
         # ----------    other control flags for bwd   --------- #
 
-        # NOTE: concat dkv together for comm only when not using native grpcoll and world_size > 1
-        self.concat_dkv = (not self.skip_comm) and (not self.use_native_grpcoll)
+        # NOTE: concat dkv together for comm only when not using native grpcoll
+        # and world_size > 1; same asymmetric K/V gate as concat_kv above.
+        self.concat_dkv = (
+            (not self.skip_comm)
+            and (not self.use_native_grpcoll)
+            and (not self.is_asymmetric_kv)
+        )
 
         # NOTE: concat q,o,do together for comm only when enabling qo comm and not using native grpcoll and world_size > 1
         self.concat_qo_do = (
@@ -1485,8 +1501,27 @@ class DistAttnRuntime:
                 for i = 0, 1, ..., overlap_degree - 1
         """
 
+        # MLA-style asymmetric K/V (d_qk != d_v): concat K and V along the
+        # head_dim (last) axis to form a single fused tensor of shape
+        # [seqlen, h, d_k + d_v]. The comm primitive still partitions dim 0
+        # (tokens) just like the symmetric fused path, so the rest of the
+        # function flows through the existing fused-buffer logic — only the
+        # entry (cat), the comm args (packed_times=1 — pre-baked in CommMeta),
+        # and the returned work (split-on-receive) differ.
+        asymmetric_kv = self.is_asymmetric_kv
+        if asymmetric_kv:
+            assert isinstance(local_kv, tuple) and len(local_kv) == 2, (
+                "asymmetric K/V path expects a (K, V) tuple input"
+            )
+            asym_d_k = local_kv[0].shape[-1]
+            local_kv = torch.cat(local_kv, dim=-1)  # cat-on-last-dim is contiguous
+
+        # The fused-buffer path covers both the symmetric concat_kv=True case
+        # and the asymmetric cat-on-feature case.
+        is_fused = self.concat_kv or asymmetric_kv
+
         # Prepare the meta info
-        if self.concat_kv:
+        if is_fused:
             _, num_heads, head_dim = local_kv.shape
             dtype = local_kv.dtype
             device = local_kv.device
@@ -1495,12 +1530,21 @@ class DistAttnRuntime:
             dtype = local_kv[0].dtype
             device = local_kv[0].device
 
-        # Get the group-cast args for kv
+        # Get the group-cast args for kv. CommMeta has already baked the right
+        # packed_times into kv_group_collective_args_list and the corresponding
+        # num_remote_kv_tokens_per_stage entry:
+        #   - symmetric K/V: packed_times=2 (K + V along seqlen)
+        #   - asymmetric K/V (MLA, d_qk != d_v): packed_times=1 (K, V fused
+        #     along head_dim inside this function — see the cat above)
         group_cast_arg = self.comm_meta.kv_group_collective_args_list[overlap_stage]
         group_cast_kwargs = group_cast_arg.to_group_cast_args()
-        remote_kv_seqlen = self.comm_meta.num_remote_kv_tokens_per_stage[overlap_stage]
-        if not self.concat_kv:
-            remote_kv_seqlen *= 2  # still x2 to allocate once
+        remote_kv_seqlen = self.comm_meta.num_remote_kv_tokens_per_stage[
+            overlap_stage
+        ]
+        if not self.concat_kv and not asymmetric_kv:
+            # Symmetric tuple path (e.g. native grpcoll): allocate once with
+            # the doubled seqlen, then chunk into K/V views below.
+            remote_kv_seqlen *= 2
 
         # Init remote kv buffer
         remote_kv_buffer = torch.empty(
@@ -1512,22 +1556,22 @@ class DistAttnRuntime:
         )
 
         # Compute communication bytes for nvtx logging
-        if not self.concat_kv:  # chunk to k,v individual buffers
+        if is_fused:
+            input_kv_shape = local_kv.shape
+            input_kv_dtype = local_kv.dtype
+            output_kv_shape = remote_kv_buffer.shape
+            output_kv_dtype = remote_kv_buffer.dtype
+            num_tensors = 1
+        else:  # tuple branch, symmetric K/V chunked into individual buffers
             remote_kv_buffer = self._maybe_chunk(remote_kv_buffer, num_chunks=2)
             input_kv_shape = local_kv[0].shape
             input_kv_dtype = local_kv[0].dtype
             output_kv_shape = remote_kv_buffer[0].shape
             output_kv_dtype = remote_kv_buffer[0].dtype
             num_tensors = 2
-        else:
-            input_kv_shape = local_kv.shape
-            input_kv_dtype = local_kv.dtype
-            output_kv_shape = remote_kv_buffer.shape
-            output_kv_dtype = remote_kv_buffer.dtype
-            num_tensors = 1
         group_cast_kv_bytes = self._compute_grpcoll_bytes(
             comm_tokens=group_cast_arg.group_cast_comm_tokens * num_tensors,
-            input=local_kv if self.concat_kv else local_kv[0],
+            input=local_kv if is_fused else local_kv[0],
         )
 
         # Compute RDMA communication bytes for nvtx logging
@@ -1536,7 +1580,7 @@ class DistAttnRuntime:
         )
         group_cast_kv_rdma_bytes = self._compute_grpcoll_bytes(
             comm_tokens=internode_output_seqlen * num_tensors,
-            input=local_kv if self.concat_kv else local_kv[0],
+            input=local_kv if is_fused else local_kv[0],
         )
 
         # Launch group cast kernel
@@ -1549,7 +1593,8 @@ class DistAttnRuntime:
                 f"{input_kv_dtype=} | "
                 f"{output_kv_shape=} | "
                 f"{output_kv_dtype=} | "
-                f"{num_tensors=}"
+                f"{num_tensors=} | "
+                f"{asymmetric_kv=}"
             )
         ):
             remote_kv_work = group_cast(
@@ -1561,6 +1606,19 @@ class DistAttnRuntime:
                 buffer_name=buffer_name,
                 kernel_barrier=kernel_barrier,
             )
+
+        # For asymmetric: wrap the work so wait_post_process splits the fused
+        # buffer back into a (remote_k, remote_v) tuple along the head_dim.
+        # We hijack the post_process_fn chain on the same underlying work; no
+        # extra class needed.
+        if asymmetric_kv:
+            inner_pp = remote_kv_work.post_process_fn
+
+            def _split_post_process(buf, _inner=inner_pp, _dk=asym_d_k):
+                ready = _inner(buf)
+                return ready[..., :_dk].contiguous(), ready[..., _dk:].contiguous()
+
+            remote_kv_work.post_process_fn = _split_post_process
 
         return remote_kv_work, remote_kv_buffer
 
@@ -2088,8 +2146,34 @@ class DistAttnRuntime:
             partial_dkv_reduce_work (WorkWithPostProcessFn): partial dkv group-reduce work
         """
 
+        # MLA-style asymmetric K/V (d_qk != d_v): concat dK and dV along the
+        # head_dim (last) axis into a single fused tensor, then go through the
+        # standard fused-buffer reduce path. Bandwidth = seqlen * h * (d_k+d_v).
+        asymmetric_kv = self.is_asymmetric_kv
+        if asymmetric_kv:
+            assert isinstance(ref_remote_dkv, tuple) and len(ref_remote_dkv) == 2
+            asym_d_k = ref_remote_dkv[0].shape[-1]
+            # partial_local_dkv is always a tuple here (concat_dkv=False).
+            assert isinstance(partial_local_dkv, tuple)
+            # Cache the fused local-dkv buffer for the lifetime of one bwd call
+            # so ALL overlap stages accumulate into the SAME tensor (mirror of
+            # the symmetric concat_dkv=True path which reuses one
+            # partial_local_dkv across stages). Reset in `_reset_work_list`.
+            if self._asym_fused_local_dkv is None:
+                self._asym_fused_local_dkv = torch.cat(
+                    partial_local_dkv, dim=-1
+                )  # cat-on-last-dim is contiguous
+            partial_local_dkv = self._asym_fused_local_dkv
+            if isinstance(partial_remote_dkv, tuple):
+                partial_remote_dkv = torch.cat(partial_remote_dkv, dim=-1)
+            ref_remote_dkv = torch.cat(ref_remote_dkv, dim=-1)
+
+        # The fused-buffer path covers both symmetric concat_dkv=True and the
+        # asymmetric cat-on-feature case.
+        is_fused = self.concat_kv or asymmetric_kv
+
         # Prepare the meta info
-        if self.concat_kv:  # ref_remote_dkv is a fused tensor
+        if is_fused:  # ref_remote_dkv is a fused tensor
             dtype = ref_remote_dkv.dtype
             device = ref_remote_dkv.device
             remote_dkv_shape = ref_remote_dkv.shape
@@ -2101,7 +2185,8 @@ class DistAttnRuntime:
                 *ref_remote_dkv[0].shape[1:],
             )
 
-        # Get the group-reduce args for dkv
+        # Get the group-reduce args for dkv. CommMeta has already baked
+        # packed_times (1 for asymmetric, 2 for symmetric) into the arg list.
         group_reduce_arg = self.comm_meta.kv_group_collective_args_list[overlap_stage]
         group_reduce_kwargs = group_reduce_arg.to_group_reduce_args()
 
@@ -2121,10 +2206,12 @@ class DistAttnRuntime:
                 ),
                 device=device,
             )
-            if not self.concat_dkv:
+            if not is_fused:
                 partial_remote_dkv = self._maybe_chunk(partial_remote_dkv, num_chunks=2)
         elif not self.use_native_grpcoll and not self.bwd_hp_reduce:
-            assert self.concat_dkv
+            # Asymmetric path already fused above into single tensors; symmetric
+            # tuple path is rejected here (matches the original assertion).
+            assert is_fused
             # Downcast to the same dtype as dkv
             # if using non-native grpcoll and not reduce in high-precision
             partial_remote_dkv = partial_remote_dkv.to(dtype)
@@ -2140,7 +2227,7 @@ class DistAttnRuntime:
             )
 
         # Compute communication bytes for nvtx logging
-        if self.concat_dkv:
+        if is_fused:
             input_dkv_shape = partial_remote_dkv.shape
             input_dkv_dtype = partial_remote_dkv.dtype
             output_dkv_shape = partial_local_dkv.shape
@@ -2154,7 +2241,7 @@ class DistAttnRuntime:
             num_tensors_of_dkv = 2
         group_reduce_dkv_bytes = self._compute_grpcoll_bytes(
             comm_tokens=group_reduce_arg.group_reduce_comm_tokens * num_tensors_of_dkv,
-            input=partial_remote_dkv if self.concat_dkv else partial_remote_dkv[0],  # type: ignore
+            input=partial_remote_dkv if is_fused else partial_remote_dkv[0],  # type: ignore
         )
 
         # Compute RDMA communication bytes for nvtx logging
@@ -2163,7 +2250,7 @@ class DistAttnRuntime:
         )
         group_reduce_dkv_rdma_bytes = self._compute_grpcoll_bytes(
             comm_tokens=internode_output_seqlen * num_tensors_of_dkv,
-            input=partial_remote_dkv if self.concat_dkv else partial_remote_dkv[0],  # type: ignore
+            input=partial_remote_dkv if is_fused else partial_remote_dkv[0],  # type: ignore
         )
 
         # Launch group-reduce kernel
@@ -2176,7 +2263,8 @@ class DistAttnRuntime:
                 f"{input_dkv_dtype=} | "
                 f"{output_dkv_shape=} | "
                 f"{output_dkv_dtype=} | "
-                f"{num_tensors_of_dkv=}"
+                f"{num_tensors_of_dkv=} | "
+                f"{asymmetric_kv=}"
             )
         ):
             partial_dkv_reduce_work = group_reduce(
@@ -2189,6 +2277,23 @@ class DistAttnRuntime:
                 buffer_name=buffer_name,
                 kernel_barrier=kernel_barrier,
             )
+
+        # For asymmetric: hijack the post_process_fn to split the fused local
+        # dkv buffer back into a (dk, dv) tuple along the head_dim. The caller
+        # passes its own local_dkv tuple to wait_post_process, but we know
+        # the underlying reduce wrote into our cached fused buffer.
+        if asymmetric_kv:
+            inner_pp = partial_dkv_reduce_work.post_process_fn
+            fused_local_capture = partial_local_dkv
+
+            def _split_post_process(
+                _local_dkv_tuple, _inner=inner_pp, _fused=fused_local_capture,
+                _dk=asym_d_k,
+            ):
+                ready = _inner(_fused)
+                return ready[..., :_dk].contiguous(), ready[..., _dk:].contiguous()
+
+            partial_dkv_reduce_work.post_process_fn = _split_post_process
 
         return partial_dkv_reduce_work
 
@@ -2976,6 +3081,10 @@ class DistAttnRuntime:
             None
         ] * self.overlap_degree  # bwd
         self.partial_dsink_reduce_work: WorkWithPostProcessFn = None  # bwd
+        # MLA-style asymmetric K/V: fused local-dkv buffer cache (one per bwd
+        # call, shared across all overlap stages so reductions accumulate
+        # into the same tensor).
+        self._asym_fused_local_dkv: torch.Tensor | None = None
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DistAttnRuntime):
@@ -3047,6 +3156,7 @@ class DistAttnFunc(torch.autograd.Function):
                 softcap=softcap,
                 return_max_logits=return_max_logits,
             )
+
 
         # init kernel barrier for native grpcoll to ensure comm kernel is always preceded by compute kernel
         kernel_barrier_fetch = KernelBarrier(

--- a/magi_attention/functional/dist_attn.py
+++ b/magi_attention/functional/dist_attn.py
@@ -157,6 +157,7 @@ class DistAttnRuntime:
     partial_dq_reduce_work_per_stage: list[WorkWithPostProcessFn]
     partial_dkv_reduce_work_per_stage: list[WorkWithPostProcessFn]
     partial_dsink_reduce_work: WorkWithPostProcessFn
+    _asym_fused_local_dkv: torch.Tensor | None
 
     def __init__(
         self,
@@ -691,10 +692,6 @@ class DistAttnRuntime:
         _softmax_scale: float = (
             q.shape[-1] ** -0.5 if softmax_scale is None else softmax_scale
         )
-        if self.concat_kv:  # kv is a fused tensor
-            dkv_shape = kv.shape
-        else:  # kv are tupled tensors
-            dkv_shape = (k.shape[0] * 2, *k.shape[1:])
 
         # attention backward pass
         (
@@ -714,7 +711,6 @@ class DistAttnRuntime:
             softmax_scale=_softmax_scale,
             softcap=softcap,
             is_host_stage=is_host_stage,
-            dkv_shape=dkv_shape,
         )
 
         # maybe downcast dq,dkv to q,kv dtype for the host stage
@@ -1353,7 +1349,6 @@ class DistAttnRuntime:
         softmax_scale: float,
         softcap: float,
         is_host_stage: bool,
-        dkv_shape: tuple[int, ...],
     ) -> tuple[torch.Tensor, FusedOrTupleTensor, torch.Tensor | None]:
         _backend = self.kernel_backend
         with nvtx.add_nvtx_event(
@@ -1417,6 +1412,11 @@ class DistAttnRuntime:
                     partial_dk, partial_dv, need_concat=self.concat_dkv
                 )
             else:
+                assert k.shape == v.shape, (
+                    "The fused dKV buffer requires symmetric K/V shapes, "
+                    f"but got {k.shape=} and {v.shape=}."
+                )
+                dkv_shape = (k.shape[0] * 2, *k.shape[1:])
                 # init partial_dkv buffer
                 # NOTE: we initial partial dkv and chunk to dk, dv to avoid concat them back before return
                 # and we need to zero-initialize partial_dkv since it needs to be reduced
@@ -1510,9 +1510,9 @@ class DistAttnRuntime:
         # and the returned work (split-on-receive) differ.
         asymmetric_kv = self.is_asymmetric_kv
         if asymmetric_kv:
-            assert isinstance(local_kv, tuple) and len(local_kv) == 2, (
-                "asymmetric K/V path expects a (K, V) tuple input"
-            )
+            assert (
+                isinstance(local_kv, tuple) and len(local_kv) == 2
+            ), "asymmetric K/V path expects a (K, V) tuple input"
             asym_d_k = local_kv[0].shape[-1]
             local_kv = torch.cat(local_kv, dim=-1)  # cat-on-last-dim is contiguous
 
@@ -1538,9 +1538,7 @@ class DistAttnRuntime:
         #     along head_dim inside this function — see the cat above)
         group_cast_arg = self.comm_meta.kv_group_collective_args_list[overlap_stage]
         group_cast_kwargs = group_cast_arg.to_group_cast_args()
-        remote_kv_seqlen = self.comm_meta.num_remote_kv_tokens_per_stage[
-            overlap_stage
-        ]
+        remote_kv_seqlen = self.comm_meta.num_remote_kv_tokens_per_stage[overlap_stage]
         if not self.concat_kv and not asymmetric_kv:
             # Symmetric tuple path (e.g. native grpcoll): allocate once with
             # the doubled seqlen, then chunk into K/V views below.
@@ -2170,7 +2168,7 @@ class DistAttnRuntime:
 
         # The fused-buffer path covers both symmetric concat_dkv=True and the
         # asymmetric cat-on-feature case.
-        is_fused = self.concat_kv or asymmetric_kv
+        is_fused = self.concat_dkv or asymmetric_kv
 
         # Prepare the meta info
         if is_fused:  # ref_remote_dkv is a fused tensor
@@ -2287,7 +2285,9 @@ class DistAttnRuntime:
             fused_local_capture = partial_local_dkv
 
             def _split_post_process(
-                _local_dkv_tuple, _inner=inner_pp, _fused=fused_local_capture,
+                _local_dkv_tuple,
+                _inner=inner_pp,
+                _fused=fused_local_capture,
                 _dk=asym_d_k,
             ):
                 ready = _inner(_fused)
@@ -3084,7 +3084,7 @@ class DistAttnRuntime:
         # MLA-style asymmetric K/V: fused local-dkv buffer cache (one per bwd
         # call, shared across all overlap stages so reductions accumulate
         # into the same tensor).
-        self._asym_fused_local_dkv: torch.Tensor | None = None
+        self._asym_fused_local_dkv = None
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DistAttnRuntime):
@@ -3156,7 +3156,6 @@ class DistAttnFunc(torch.autograd.Function):
                 softcap=softcap,
                 return_max_logits=return_max_logits,
             )
-
 
         # init kernel barrier for native grpcoll to ensure comm kernel is always preceded by compute kernel
         kernel_barrier_fetch = KernelBarrier(
@@ -3458,7 +3457,6 @@ class DistAttnFunc(torch.autograd.Function):
         _softmax_scale: float = (
             q.shape[-1] ** -0.5 if softmax_scale is None else softmax_scale
         )
-        dkv_shape = (full_k.shape[0] * 2, *full_k.shape[1:])
 
         # -- Step 6: single backward call with merged arg --
         (
@@ -3478,7 +3476,6 @@ class DistAttnFunc(torch.autograd.Function):
             softmax_scale=_softmax_scale,
             softcap=softcap,
             is_host_stage=True,
-            dkv_shape=dkv_shape,
         )
 
         # -- Step 7: split dkv into local and remote parts --

--- a/magi_attention/functional/fa4.py
+++ b/magi_attention/functional/fa4.py
@@ -35,7 +35,7 @@ except ImportError:
     pass
 
 try:
-    # Original DSL interface.
+    # FFA_FA4 DSL interface.
     from flash_attn_cute.interface import _flash_attn_bwd, _flash_attn_fwd
 
     _has_cute_backend = True
@@ -209,7 +209,7 @@ def fa4_fwd(
             pack_gqa=False,
             mask_mod=None,
             return_lse=True,
-            block_sparse_tensors=fa4_args["linear_k_block_sparse_mask"],
+            linear_k_block_sparse_tensors=fa4_args["linear_k_block_sparse_mask"],
             aux_tensors=fa4_args["aux_tensors"],
         )
 
@@ -309,7 +309,8 @@ def fa4_bwd(
             causal=False,
             arbitrary=True,  # NOTE: to enable arbitrary mask functionality
             softcap=softcap,
-            block_sparse_tensors=fa4_args["linear_q_block_sparse_mask"],
+            linear_q_block_sparse_tensors=fa4_args["linear_q_block_sparse_mask"],
+            linear_k_block_sparse_tensors=fa4_args["linear_k_block_sparse_mask"],
             aux_tensors=fa4_args["aux_tensors"],
             deterministic=deterministic,
         )
@@ -372,6 +373,7 @@ class FA4AttnFunc(torch.autograd.Function):
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
                 headdim=q.shape[-1],
+                headdim_v=v.shape[-1],
             )
             # Cache for future reuse
             FA4AttnFunc._cached_fa4_attn_arg = fa4_attn_arg

--- a/magi_attention/functional/fa4_utils.py
+++ b/magi_attention/functional/fa4_utils.py
@@ -29,7 +29,12 @@ from magi_attention.meta.collection.calc_meta import FA4AttnArg
 
 is_fa4_installed = False
 try:
-    from flash_attn_cute.interface import _flash_attn_bwd, _flash_attn_fwd
+    from flash_attn_cute.interface import (
+        _bwd_postprocess_convert,
+        _bwd_preprocess,
+        _flash_attn_bwd,
+        _flash_attn_fwd,
+    )
 
     is_fa4_installed = True
 except ImportError:
@@ -97,7 +102,7 @@ COMPILED_META_DICT = {
         ],
     },
     "bwd_pre": {
-        "cache_dict": _flash_attn_bwd.compile_cache_pre,
+        "cache_dict": _bwd_preprocess.compile_cache,
         "arg_names": [
             "out",
             "dout",
@@ -111,7 +116,7 @@ COMPILED_META_DICT = {
         ],
     },
     "bwd_post": {
-        "cache_dict": _flash_attn_bwd.compile_cache_post,
+        "cache_dict": _bwd_postprocess_convert.compile_cache,
         "arg_names": [
             "accum",
             "out",

--- a/magi_attention/functional/flex_flash_attn.py
+++ b/magi_attention/functional/flex_flash_attn.py
@@ -809,6 +809,7 @@ class FlexFlashAttnFunc(torch.autograd.Function):
                 seqlen_q=q.shape[0],
                 seqlen_k=k.shape[0],
                 headdim=q.shape[-1],
+                headdim_v=v.shape[-1],
             )
 
             out, lse = fa4_fwd(

--- a/magi_attention/functional/utils.py
+++ b/magi_attention/functional/utils.py
@@ -527,8 +527,12 @@ def correct_attn_out_lse(
     N_BLOCK = N  # N block size, where one head dim is always a single n block
     # Shard seqlen_q with M_BLOCK=128 on Hopper+ (CC major >= 9); use 64 on older
     # GPUs where the kernel's shared-memory usage at M_BLOCK=128 exceeds the limit.
+    # Also drop to 64 when the head_dim tile is large (>=256): the kernel keeps
+    # both the input and output tiles in shared memory as fp32, and
+    # 128 * 256 * 4 (out) + 128 * 256 * 4 (inp) ~= 256 KiB which overflows even
+    # Blackwell's per-SM SMEM.
     sm_major, _ = torch.cuda.get_device_capability(out1.device)
-    M_BLOCK = 64 if sm_major < 9 else 128
+    M_BLOCK = 64 if (sm_major < 9 or N_BLOCK >= 256) else 128
     NUM_M_BLOCKS = triton.cdiv(M, M_BLOCK)  # number of M blocks along seqlen_q
 
     grid = (NUM_M_BLOCKS, H)

--- a/magi_attention/meta/_make_attn_meta.py
+++ b/magi_attention/meta/_make_attn_meta.py
@@ -49,6 +49,7 @@ def make_attn_meta_from_dispatch_meta(
     overlap_config: OverlapConfig,
     cp_group: dist.ProcessGroup,
     cp_mesh: DeviceMesh | None = None,
+    head_dim_v: int | None = None,
 ) -> tuple[CommMeta, CalcMeta, BaseDistAttnSolver]:
     """Make the communication and calculation meta from the dispatch meta
 
@@ -87,6 +88,7 @@ def make_attn_meta_from_dispatch_meta(
             dispatch_meta_q=dispatch_meta_q,
             dispatch_meta_k=dispatch_meta_k,
             cp_mesh=cp_mesh,
+            head_dim_v=head_dim_v,
         )
         attn_solver.solve(
             q_ranges=q_ranges,
@@ -107,6 +109,7 @@ def make_attn_meta_from_dispatch_meta(
             overlap_config=overlap_config,
             cp_group=cp_group,
             cp_mesh=cp_mesh,
+            head_dim_v=head_dim_v,
         )
         attn_solver.solve(
             q_ranges=q_ranges,

--- a/magi_attention/meta/collection/calc_meta.py
+++ b/magi_attention/meta/collection/calc_meta.py
@@ -100,6 +100,7 @@ class AttnArg:
         # init `skip_attn_fwd` flag
         batch_size_fwd = len(self.q_ranges)
         self.skip_attn_fwd = batch_size_fwd == 0
+        self.disable_fwd_atomic_reduction = False
 
         # guard clause
         if self.skip_attn_fwd:
@@ -169,6 +170,7 @@ class AttnArg:
         self.q_ranges_bwd = self.q_ranges
         self.k_ranges_bwd = self.k_ranges
         self.attn_type_map_bwd = self.attn_type_map
+        self.disable_bwd_dkv_atomic_reduction = False
 
         # guard clause
         if self.skip_attn_bwd:

--- a/magi_attention/meta/collection/calc_meta.py
+++ b/magi_attention/meta/collection/calc_meta.py
@@ -46,11 +46,16 @@ try:
         LinearBlockSparseTensorsTorch,
         bhqk_to_linear_sparse_tensors,
     )
-    from flash_attn_cute.mask_definitions import flex_arbitrary_mask
 
     is_fa4_installed = True
 except ImportError:
     pass
+
+# Optional: only needed for FA4AttnArg.compute_mask with arbitrary masks
+try:
+    from flash_attn_cute.mask_definitions import flex_arbitrary_mask
+except ImportError:
+    flex_arbitrary_mask = None  # type: ignore[assignment]
 
 try:
     COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
@@ -274,9 +279,10 @@ class AttnArg:
 def _resolve_tile_sizes(pass_type: str, headdim: int = 128) -> tuple[int, int]:
     """Resolve the correct **mask** tile sizes for the current GPU architecture.
 
-    On SM100 (Blackwell) the mask tile is always 128x128; the kernel
-    internally doubles the M dimension (``sparse_tile_m = 2 * tile_m``)
-    in ``_make_fa4_args_dict``.
+    On SM100 (Blackwell) the base mask tile is 128x128. Forward uses a
+    q-stage-dependent Q2K block. Backward K2Q granularity is path-specific:
+    the 128/128 and 192/128 2CTA paths use 128x256, while the dedicated
+    256/256 path uses 256x128.
 
     On SM80/SM90, the tile sizes depend on ``headdim`` and are queried
     from the C++ (hopper) backend via ``get_tile_sizes_by_backend``.
@@ -305,10 +311,17 @@ class FA4AttnArg(AttnArg):
     seqlen_q: int = 0
     seqlen_k: int = 0
     headdim: int = 128
+    headdim_v: int | None = None
+    # Q-heads-per-KV-head ratio (== num_heads_q / num_heads_kv). Needed so we can
+    # compute the same fwd `q_stage` as the FA cute backend uses, and build the
+    # block-sparse mask at a matching Q granularity.
+    qhead_per_kvhead: int = 1
 
     def __post_init__(self):
         assert is_fa4_installed, "FlashAttn4 is not installed"
         assert is_magi_to_hstu_installed, "magi_to_hstu_cuda is not installed"
+        if self.headdim_v is None:
+            self.headdim_v = self.headdim
 
         # DEVIATION: sentinel tile sizes (-1) are replaced with arch-specific defaults
         # Reason: -1 is a user-facing sentinel meaning "auto-detect"; the kernel
@@ -336,7 +349,7 @@ class FA4AttnArg(AttnArg):
                 f"FA4 mask tile size on SM {COMPUTE_CAPABILITY}.0 must be "
                 f"{_DEFAULT_FA4_TILE_SIZE}, got fwd=({self.tile_m}, {self.tile_n}), "
                 f"bwd=({self.tile_m_bwd}, {self.tile_n_bwd}). "
-                f"The kernel internally doubles tile_m via sparse_tile_m."
+                f"The SM100 kernel internally expands the linear CSR block size."
             )
 
         super().__post_init__()
@@ -355,10 +368,31 @@ class FA4AttnArg(AttnArg):
         tile_m: int,
         tile_n: int,
     ) -> dict:
+        # Match FA cute backend's `q_stage` heuristic exactly so the sparse mask
+        # we build lines up with `base_m_block = q_stage * tile_m` on the kernel
+        # side (otherwise infer_linear_block_sparse_expected_shapes rejects us).
         if COMPUTE_CAPABILITY == 10:
-            sparse_tile_m = 2 * tile_m
+            seqlen_q_packgqa = self.seqlen_q * self.qhead_per_kvhead
+            q_stage_fwd = 2 if seqlen_q_packgqa > tile_m else 1
         else:
-            sparse_tile_m = tile_m
+            q_stage_fwd = 1
+        sparse_tile_m = q_stage_fwd * tile_m
+        if COMPUTE_CAPABILITY in (10, 11) and (
+            (self.headdim, self.headdim_v) in ((128, 128), (192, 128))
+        ):
+            # The two CTAs form a cluster along N only. Each K2Q CSR Q index
+            # therefore maps directly to one M tile.
+            bwd_sparse_tile_m = tile_m
+            bwd_sparse_tile_n = 2 * tile_n
+        elif COMPUTE_CAPABILITY == 10 and (
+            self.headdim,
+            self.headdim_v,
+        ) == (256, 256):
+            bwd_sparse_tile_m = 2 * tile_m
+            bwd_sparse_tile_n = tile_n
+        else:
+            bwd_sparse_tile_m = tile_m
+            bwd_sparse_tile_n = tile_n
 
         if is_magi_to_hstu_installed:
             with nvtx.add_nvtx_event(
@@ -385,16 +419,21 @@ class FA4AttnArg(AttnArg):
 
                 # Convert to LinearBlockSparseTensorsTorch format
                 # CUDA kernel returns:
-                #   - cnt: [B, H, num_blocks] - directly the counts
+                #   - cnt: [B, H, num_blocks] - kept 3D for FA-cute (>=v1.1.1) expected layout
                 #   - offset: [B * H * num_blocks + 1] - flattened exclusive prefix sum (starts with 0)
                 #   - idx: [total_blocks] - compact indices
                 linear_k_block_sparse_mask = LinearBlockSparseTensorsTorch(
-                    mask_block_cnt=cuda_k_mask_cnt.flatten(),
+                    mask_block_cnt=cuda_k_mask_cnt,
                     mask_block_offset=cuda_k_mask_offset,
                     mask_block_idx=cuda_k_mask_idx,
-                    full_block_cnt=cuda_k_full_cnt.flatten(),
+                    full_block_cnt=cuda_k_full_cnt,
                     full_block_offset=cuda_k_full_offset,
                     full_block_idx=cuda_k_full_idx,
+                    # The fwd path (and the dq half of bwd) sets q_stage=2 on sm100,
+                    # so base_m_block = q_stage * tile_m = sparse_tile_m. Declare the
+                    # block size explicitly so the new FA backend doesn't have to infer
+                    # it (which fails when seqlen_q <= sparse_tile_m gives only 1 q-block).
+                    block_size=(sparse_tile_m, tile_n),
                 )
             with nvtx.add_nvtx_event(
                 f"create_k2q_csr_sparse_from_func-"
@@ -413,17 +452,19 @@ class FA4AttnArg(AttnArg):
                     hstu_func,
                     self.seqlen_q,
                     self.seqlen_k,
-                    Q_BLOCK_SIZE=tile_m,
-                    KV_BLOCK_SIZE=tile_n,
+                    Q_BLOCK_SIZE=bwd_sparse_tile_m,
+                    KV_BLOCK_SIZE=bwd_sparse_tile_n,
                 )
 
                 linear_q_block_sparse_mask = LinearBlockSparseTensorsTorch(
-                    mask_block_cnt=cuda_q_mask_cnt.flatten(),
+                    mask_block_cnt=cuda_q_mask_cnt,
                     mask_block_offset=cuda_q_mask_offset,
                     mask_block_idx=cuda_q_mask_idx,
-                    full_block_cnt=cuda_q_full_cnt.flatten(),
+                    full_block_cnt=cuda_q_full_cnt,
                     full_block_offset=cuda_q_full_offset,
                     full_block_idx=cuda_q_full_idx,
+                    # Match the K2Q CSR block to the selected backward attention tile.
+                    block_size=(bwd_sparse_tile_m, bwd_sparse_tile_n),
                 )
         else:
             # Prepare mask_mod
@@ -459,7 +500,7 @@ class FA4AttnArg(AttnArg):
                 self.seqlen_q,
                 self.seqlen_k,
                 device="cuda",
-                BLOCK_SIZE=(tile_m, tile_n),
+                BLOCK_SIZE=(bwd_sparse_tile_m, bwd_sparse_tile_n),
             )
             (
                 _,
@@ -702,6 +743,8 @@ class FA4AttnArg(AttnArg):
         repr_str += f"{indent}    tile_n_bwd={self.tile_n_bwd},\n"
         repr_str += f"{indent}    seqlen_q={self.seqlen_q},\n"
         repr_str += f"{indent}    seqlen_k={self.seqlen_k},\n"
+        repr_str += f"{indent}    headdim={self.headdim},\n"
+        repr_str += f"{indent}    headdim_v={self.headdim_v},\n"
         repr_str += f"{indent}    n_func={self.n_func},\n"
 
         repr_str += f"{indent}    # Generated by _transfer_ffa_args_to_fa4_args:\n"
@@ -726,11 +769,15 @@ class CalcMeta:
 
     # Specific meta for FA4 backend
     headdim: int = 128
+    headdim_v: int | None = None
     seqlen_q_shard: int = 0  # local q seqlen from dispatch_meta
     seqlen_k_local: int = 0  # for local_attn_arg
     seqlen_k_per_remote_stage: list[int] = field(
         default_factory=list
     )  # for remote_attn_args_list
+    # Q-heads-per-KV-head ratio. Used by the FA4 path to match the cute backend's
+    # `q_stage` heuristic when building the block-sparse mask. Default 1 (MHA).
+    qhead_per_kvhead: int = 1
 
     @property
     def overlap_degree(self) -> int:
@@ -767,6 +814,8 @@ class CalcMeta:
                 seqlen_q=self.seqlen_q_shard,
                 seqlen_k=self.seqlen_k_local,
                 headdim=self.headdim,
+                headdim_v=self.headdim_v,
+                qhead_per_kvhead=self.qhead_per_kvhead,
             )
             # DEVIATION: remote_attn_args_list entries (AttnArg) replaced with FA4AttnArg
             # Reason: same as local_attn_arg above — FA4 backend requirement.
@@ -785,6 +834,8 @@ class CalcMeta:
                     seqlen_q=self.seqlen_q_shard,
                     seqlen_k=self.seqlen_k_per_remote_stage[stage],
                     headdim=self.headdim,
+                    headdim_v=self.headdim_v,
+                    qhead_per_kvhead=self.qhead_per_kvhead,
                 )
 
         if self.no_overlap and self.overlap_degree > 0:
@@ -845,6 +896,8 @@ class CalcMeta:
                 seqlen_q=self.seqlen_q_shard,
                 seqlen_k=merged_seqlen_k,
                 headdim=self.headdim,
+                headdim_v=self.headdim_v,
+                qhead_per_kvhead=self.qhead_per_kvhead,
             )
 
         return AttnArg(

--- a/magi_attention/meta/collection/comm_meta.py
+++ b/magi_attention/meta/collection/comm_meta.py
@@ -583,6 +583,12 @@ class CommMeta:
     num_heads_q: int
     num_heads_kv: int
     head_dim: int
+    # NOTE: MLA-style asymmetric K/V (d_qk != d_v). When None, treated as
+    # symmetric (head_dim_v = head_dim). Affects the packed_times baked into
+    # kv_group_collective_args_list (2 for symmetric, 1 for asymmetric — the
+    # asymmetric path fuses K and V along the head_dim axis at comm time so
+    # only one tensor's worth of tokens flows through group_cast/reduce).
+    head_dim_v: int | None = None
 
     @property
     def overlap_degree(self) -> int:
@@ -591,6 +597,11 @@ class CommMeta:
     @property
     def num_heads_per_group(self) -> int:
         return self._num_heads_per_group
+
+    @property
+    def is_asymmetric_kv(self) -> bool:
+        """True when d_qk != d_v (MLA-style)."""
+        return self.head_dim_v is not None and self.head_dim_v != self.head_dim
 
     def __post_init__(self):
         assert (
@@ -632,14 +643,24 @@ class CommMeta:
 
         And the original args will also be inplace modified
 
-        - num_remote_kv_tokens_per_stage will time by 2
+        - num_remote_kv_tokens_per_stage:
+            * symmetric K/V: times by 2 (K and V packed along seqlen)
+            * asymmetric K/V (MLA, d_qk != d_v): stays the same (K and V
+              packed along head_dim at comm time; only seqlen worth of
+              tokens are sent per stage)
         - kv_group_collective_args_list will become `list[A2AVBasedGroupCollectiveArg]`
-        with packed_times=2 and reduce_op="sum"
+            * symmetric K/V: packed_times=2 with reduce_op="sum"
+            * asymmetric K/V: packed_times=1 with reduce_op="sum"
 
         - num_remote_qo_tokens_per_stage will stay the same
         - qo_group_collective_args_list will become `list[A2AVBasedGroupCollectiveArg]`
         with packed_times=1 and reduce_op="sum"
         """
+
+        # KV is packed along seqlen (packed_times=2) when symmetric, but along
+        # the head_dim axis (packed_times=1) when asymmetric — see comments on
+        # `is_asymmetric_kv` and `_fetch_remote_kv` in functional/dist_attn.py.
+        kv_packed_times = 1 if self.is_asymmetric_kv else 2
 
         # -----     init a2a-v based group collective args     ----- #
 
@@ -651,15 +672,21 @@ class CommMeta:
             num_remote_kv_tokens = self.num_remote_kv_tokens_per_stage[stage]
             kv_group_collective_kwargs = vars(self.kv_group_collective_args_list[stage])
 
-            # DEVIATION: num_remote_kv_tokens_per_stage[stage] multiplied by 2 in-place,
-            #   kv_group_collective_args_list[stage] replaced with A2AVBasedGroupCollectiveArg
-            # Reason: KV and dKV are packed along the seqlen dim for fused fetch/reduce,
-            #   so the token count must double and the collective arg must carry packed_times=2.
-            # Recovery: original token count is num_remote_kv_tokens_per_stage[stage] // 2.
-            self.num_remote_kv_tokens_per_stage[stage] = num_remote_kv_tokens * 2
+            # DEVIATION: num_remote_kv_tokens_per_stage[stage] multiplied by `kv_packed_times`
+            # in-place; kv_group_collective_args_list[stage] replaced with
+            # A2AVBasedGroupCollectiveArg(packed_times=kv_packed_times).
+            # Reason: symmetric K/V (kv_packed_times=2) packs K then V along
+            # the seqlen dim for fused fetch/reduce; asymmetric K/V
+            # (kv_packed_times=1) packs them along head_dim instead, so the
+            # token count stays at seqlen.
+            # Recovery: original token count is num_remote_kv_tokens_per_stage[stage]
+            # // kv_packed_times.
+            self.num_remote_kv_tokens_per_stage[stage] = (
+                num_remote_kv_tokens * kv_packed_times
+            )
             self.kv_group_collective_args_list[stage] = A2AVBasedGroupCollectiveArg(
                 **kv_group_collective_kwargs,
-                packed_times=2,  # pack kv/dkv along seqlen dim
+                packed_times=kv_packed_times,
                 reduce_op="sum",  # sum-reduce dkv
                 init_group_reduce=True,
             )

--- a/magi_attention/meta/solver/dist_attn_solver.py
+++ b/magi_attention/meta/solver/dist_attn_solver.py
@@ -215,6 +215,7 @@ class DistAttnSolver(BaseDistAttnSolver):
         overlap_config: OverlapConfig,
         cp_group: dist.ProcessGroup,
         cp_mesh: DeviceMesh | None = None,
+        head_dim_v: int | None = None,
     ):
         assert (
             not env.comm.is_qo_comm_enable()
@@ -235,6 +236,7 @@ class DistAttnSolver(BaseDistAttnSolver):
         self.num_heads_kv = num_heads_kv
         self.num_heads_group = 1
         self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
 
         # NOTE: the real overlap degree should be determined in the later code:
         # 1. if overlap mode is static, then its real value equals to the one in the overlap config
@@ -1705,6 +1707,7 @@ class DistAttnSolver(BaseDistAttnSolver):
             num_heads_q=self.org_num_heads_q,
             num_heads_kv=self.org_num_heads_kv,
             head_dim=self.head_dim,
+            head_dim_v=self.head_dim_v,
         )
 
         return comm_meta
@@ -1911,9 +1914,11 @@ class DistAttnSolver(BaseDistAttnSolver):
             remote_attn_args_list=remote_attn_args_list,
             no_overlap=self.overlap_config.no_overlap,
             headdim=self.head_dim,
+            headdim_v=self.head_dim_v,
             seqlen_q_shard=self.shard_seqlen_q,
             seqlen_k_local=self.host_rank_entry_this_rank.host_k_ranges_global.total_seqlen,
             seqlen_k_per_remote_stage=seqlen_k_per_remote_stage,
+            qhead_per_kvhead=self.org_num_heads_q // self.org_num_heads_kv,
         )
 
         return calc_meta

--- a/magi_attention/meta/solver/dynamic_attn_solver.py
+++ b/magi_attention/meta/solver/dynamic_attn_solver.py
@@ -65,6 +65,7 @@ class DynamicAttnSolver(BaseDistAttnSolver):
         cp_size: int | None = None,
         cp_mesh: DeviceMesh | None = None,
         calc_local_range: bool = True,
+        head_dim_v: int | None = None,
     ):
         self.algorithm = algorithm
         self.cp_group = cp_group
@@ -108,6 +109,7 @@ class DynamicAttnSolver(BaseDistAttnSolver):
         self.num_heads_kv = num_heads_kv
         self.num_heads_group = 1
         self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
 
         # set some attributes that might be fetched from outside
         self.host_q_ranges_global = self.host_ranges_q[self.cp_rank]
@@ -537,6 +539,7 @@ class DynamicAttnSolver(BaseDistAttnSolver):
             num_heads_q=self.org_num_heads_q,
             num_heads_kv=self.org_num_heads_kv,
             head_dim=self.head_dim,
+            head_dim_v=self.head_dim_v,
         )
 
         return comm_meta
@@ -675,6 +678,8 @@ class DynamicAttnSolver(BaseDistAttnSolver):
             local_attn_arg=local_attn_arg,
             remote_attn_args_list=remote_attn_args_list,
             headdim=self.head_dim,
+            headdim_v=self.head_dim_v,
+            qhead_per_kvhead=self.org_num_heads_q // self.org_num_heads_kv,
         )
 
         return calc_meta

--- a/magi_attention/testing/ref_attn.py
+++ b/magi_attention/testing/ref_attn.py
@@ -55,13 +55,13 @@ class RefAttnTorchImplMainProcessOnline(torch.autograd.Function):
         # fetch meta info
         # q.shape = [nhq, sq, d]
         # kt.shape = [nhq, d, sk]
-        # v.shape = [nhq, sk, d]
+        # v.shape = [nhq, sk, dv]
         sq, sk, nhq = q.size(-2), kt.size(-1), q.size(0)
         lse_dtype = max_fp_dtype(q.dtype, torch.float32)
 
         # init out buffer
-        # out.shape = [nhq, sq, d]
-        out = torch.zeros_like(q)
+        # out.shape = [nhq, sq, dv]
+        out = q.new_zeros((*q.shape[:-1], v.shape[-1]))
 
         # init max_logits per head only when needed
         if return_max_logits:

--- a/scripts/install_flash_attn_cute.sh
+++ b/scripts/install_flash_attn_cute.sh
@@ -17,7 +17,7 @@
 # Example:
 #   bash scripts/install_flash_attn_cute.sh "sm80,sm90,sm100"
 
-# Install cute version of ffa-fa4 for Blackwell support
+# Install FFA_FA4 for Blackwell support
 
 set -e
 
@@ -33,11 +33,16 @@ REPO_ROOT="$(pwd)"
 FA_DIR="magi_attention/functional/flash-attention"
 cd "$FA_DIR"
 
-echo "[magiattn] Installing cute ffa-fa4 (Blackwell support)"
-bash install.sh
+echo "[magiattn] Installing FFA_FA4 (Blackwell support)"
+pip install -e flash_attn/cute --no-build-isolation
+
+echo "[magiattn] Installing create_block_mask_cuda"
+pip install -e csrc/utils/create_block_mask --no-build-isolation
+
+echo "[magiattn] Installing magi_to_hstu_cuda"
+pip install -e csrc/utils/magi_to_hstu --no-build-isolation
 
 # Install cutlass version of ffa-fa4 for Ampere/Hopper support
-
 if [[ "$ARCH_ARG" == *sm80* || "$ARCH_ARG" == *sm90* ]]; then
 	cd hopper/
 
@@ -68,8 +73,7 @@ if [[ -n "$MAGI_WHEEL_DIR" ]]; then
 
 	for src_dir in \
 		"${FA_DIR}/csrc/utils/magi_to_hstu" \
-		"${FA_DIR}/csrc/utils/create_block_mask" \
-		"${FA_DIR}/flash_attn"; do
+		"${FA_DIR}/csrc/utils/create_block_mask"; do
 		if [[ -d "${REPO_ROOT}/${src_dir}" ]]; then
 			echo "[magiattn] Building wheel from ${src_dir}..."
 			(cd "${REPO_ROOT}/${src_dir}" \
@@ -78,4 +82,8 @@ if [[ -n "$MAGI_WHEEL_DIR" ]]; then
 				|| echo "[magiattn] WARNING: Could not build wheel from ${src_dir}, skipping"
 		fi
 	done
+
+	(cd "${REPO_ROOT}/${FA_DIR}/flash_attn/cute" \
+		&& pip wheel . --no-deps --no-build-isolation --wheel-dir "$MAGI_WHEEL_DIR") \
+		|| echo "[magiattn] WARNING: Could not build wheel from ${FA_DIR}/flash_attn/cute, skipping"
 fi

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,6 +79,7 @@ from magi_attention.utils.dtype import max_fp_dtype
 # (omitted or empty means all backends)
 BACKENDS = "backends"
 
+
 # TODO: rewrite the specific function for unitest profiling mode
 class TestPipelineBaseWithWorldSize1(DistTestBase):
     def init_pg(self) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,7 +79,6 @@ from magi_attention.utils.dtype import max_fp_dtype
 # (omitted or empty means all backends)
 BACKENDS = "backends"
 
-
 # TODO: rewrite the specific function for unitest profiling mode
 class TestPipelineBaseWithWorldSize1(DistTestBase):
     def init_pg(self) -> None:
@@ -885,8 +884,13 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
         ],
     )
     @parameterize(
-        "head_dim",
-        [64, 128],
+        "head_dims",
+        [
+            (64, 64),
+            (128, 128),
+            (192, 128),
+            (256, 256),
+        ],
     )
     @parameterize(
         "dtype",
@@ -908,11 +912,13 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
         self,
         attn_config: dict[str, Any],
         num_heads: tuple[int, int],  # (nhq, nhkv)
-        head_dim: int,
+        head_dims: tuple[int, int],  # (Q/K dim, V dim)
         dtype: torch.dtype,
         backend: MagiAttentionKernelBackend,
         run_bwd: bool = True,
     ):
+        head_dim, head_dim_v = head_dims
+
         # -----    skip if this attn_config is not for the current backend   ---- #
 
         allowed_backends = attn_config.get(BACKENDS, None)
@@ -981,6 +987,7 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
                 "backend": backend,
                 "num_heads": num_heads,
                 "head_dim": head_dim,
+                "head_dim_v": head_dim_v,
             }
             flag_comb = self.flag_generator.get_next_valid_comb(
                 test_config=test_config,
@@ -1025,7 +1032,7 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             f"world_size=[{self.world_size}] x "
             f"backend=[{backend.value}] x "
             f"attn_config=[{attn_config[NAME]}] x "
-            f"dtype=[{dtype}] x (nh,hd)=[({num_heads},{head_dim})] x "
+            f"dtype=[{dtype}] x (nh,hd,hdv)=[({num_heads},{head_dim},{head_dim_v})] x "
             f"has_sink=[{attn_config.get('total_seqlen_sink', 0) > 0}] x "
             + flag_comb_test_case
         )
@@ -1145,6 +1152,7 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
                 cp_group=self.nccl_group,
                 cp_mesh=self.device_mesh,
                 dist_attn_config=dist_attn_config,
+                head_dim_v=head_dim_v if head_dim_v != head_dim else None,
             )
             # HACK: seperate cp group for group-reduce
             dist_attn_runtime_mgr.dist_attn_runtime.cp_group_gr = self.nccl_groups[1]
@@ -1170,7 +1178,7 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
             total_v = torch.randn(
                 total_seqlen_k,
                 num_heads_kv,
-                head_dim,
+                head_dim_v,
                 device=self.device,
                 dtype=dtype,
                 requires_grad=run_bwd,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -919,6 +919,10 @@ class TestPipelineBaseWithWorldSize1(DistTestBase):
     ):
         head_dim, head_dim_v = head_dims
 
+        # Extended head dimensions are covered by FFA_FA4 only.
+        if head_dim > 128 and backend != MagiAttentionKernelBackend.FA4:
+            return
+
         # -----    skip if this attn_config is not for the current backend   ---- #
 
         allowed_backends = attn_config.get(BACKENDS, None)


### PR DESCRIPTION
## Summary

  - Add `head_dim_v` propagation and support SM100 configurations:
    - Q/K dim = 192, V dim = 128
    - Q/K/V dim = 256
  - Align forward q-stage selection and backward K2Q CSR metadata with the FFA_FA4 kernel tile contract.

  ## KV Communication

  - Symmetric `(256, 256)` path keeps the existing sequence-axis fusion with `packed_times=2`.
  - Asymmetric `(192, 128)` path uses MLA-style K/V packing:
    - concatenate K and V along the last head-dimension axis;
    - communicate them as one fused token stream with `packed_times=1`;
    - split the received buffer back into K and V.
  - Backward dK/dV communication follows the same fused representation and is split after reduction.
  - The asymmetric path does not use the symmetric `concat_kv`/`concat_dkv` sequence-axis packing.

  ## CSR Tile Mapping

  - `(192, 128)` backward K2Q CSR metadata uses `128x256` blocks.
  - `(256, 256)` backward K2Q CSR metadata uses `256x128` blocks.
  - Forward q-stage and CSR block sizes are selected to match the FFA_FA4 kernel.

  ## Validation

  - Ran selected SM100 FFA_FA4 tests for configurations with `n_func <= 13`.
  
  ## Related PR

  - Supersedes [MagiAttention#326](https://github.com/SandAI-org/MagiAttention/pull/326).
  - After this PR is merged, PR #326 can be closed.