### PR TITLE
[WIP]: feat(bench): Phase 8 — IndexSparse/BlockSparse baseline comparison

### DIFF
--- a/exps/attn/sparse/bench_sparse_analysis/__main__.py
+++ b/exps/attn/sparse/bench_sparse_analysis/__main__.py
@@ -116,6 +116,10 @@ def main():
             from bench_sparse_analysis.phase7_outer_store_mode import _phase7_bench
 
             _phase7_bench(force=args.force)
+        elif phase == "8-baseline-comparison":
+            from bench_sparse_analysis.phase8_baseline_comparison import _phase8_bench
+
+            _phase8_bench(force=args.force, rerun_filter=rerun_filter)
     elif args.plot:
         phase = args.plot
         print(f"[{_ts()}] === --plot {phase} ===", flush=True)
@@ -160,6 +164,12 @@ def main():
             from bench_sparse_analysis.phase6_video_production import _phase6_plot
 
             _phase6_plot()
+        elif phase == "7-outer-store-mode":
+            pass  # Phase 7 has no dedicated plot
+        elif phase == "8-baseline-comparison":
+            from bench_sparse_analysis.phase8_baseline_comparison import _phase8_plot
+
+            _phase8_plot()
     elif args.ncu:
         phase = args.ncu
         print(f"[{_ts()}] === --ncu {phase} ===", flush=True)

--- a/exps/attn/sparse/bench_sparse_analysis/_common.py
+++ b/exps/attn/sparse/bench_sparse_analysis/_common.py
@@ -46,7 +46,11 @@ COLOR_TRITON = (0.65, 0.65, 0.65)
 
 PLOT_BAR_WIDTH_RATIO = 0.8
 PLOT_BAR_ALPHA = 0.85
-PLOT_VALUE_FONTSIZE = 7
+PLOT_VALUE_FONTSIZE = 6
+PLOT_YLIM = (0, 750)
+PLOT_DPI_SAVE = 180
+PLOT_SUBPLOT_WIDTH = 8
+PLOT_SUBPLOT_HEIGHT = 7
 
 _SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _BASE_OUT = os.path.join(_SCRIPT_DIR, "outs", "sparse_analysis")
@@ -359,3 +363,69 @@ def _bench_ffa(S, topk, pass_type, kw, device):
     gc.collect()
     torch.cuda.empty_cache()
     return tf, ms
+
+
+# ── Shared plot helper ────────────────────────────────────────
+def plot_grouped_bars(
+    ax,
+    x,
+    methods,
+    data_fn,
+    *,
+    title="",
+    xlabel="",
+    ylabel="TFLOPS",
+    x_labels=None,
+    ylim=None,
+):
+    """Draw grouped bars on *ax* with unified style.
+
+    Parameters
+    ----------
+    ax : matplotlib Axes
+    x : np.ndarray of x-tick positions
+    methods : list of (method_id, label, color)
+        Ordered left-to-right. Put baselines first (grey), our kernels last.
+    data_fn : callable(method_id) -> list[float]
+        Returns TFLOPS values for each x position (0 means missing).
+    """
+
+    n_m = len(methods)
+    bw = PLOT_BAR_WIDTH_RATIO / n_m
+    for i, (mid, lbl, col) in enumerate(methods):
+        vals = data_fn(mid)
+        off = (i - n_m / 2 + 0.5) * bw
+        bars = ax.bar(
+            x + off,
+            vals,
+            width=bw,
+            label=lbl,
+            color=col,
+            edgecolor="white",
+            linewidth=0.5,
+            alpha=PLOT_BAR_ALPHA,
+        )
+        for bar, v in zip(bars, vals):
+            if v > 0:
+                ax.text(
+                    bar.get_x() + bar.get_width() / 2,
+                    bar.get_height() + 5,
+                    f"{v:.0f}",
+                    ha="center",
+                    va="bottom",
+                    fontsize=PLOT_VALUE_FONTSIZE,
+                    fontweight="bold",
+                )
+
+    ax.set_title(title, fontsize=14, fontweight="bold")
+    if xlabel:
+        ax.set_xlabel(xlabel, fontsize=10)
+    ax.set_ylabel(ylabel, fontsize=12)
+    ax.set_xticks(x)
+    if x_labels is not None:
+        ax.set_xticklabels(x_labels, fontsize=9)
+    ax.tick_params(axis="y", labelsize=11)
+    effective_ylim = ylim if ylim is not None else PLOT_YLIM
+    ax.set_ylim(*effective_ylim)
+    ax.legend(loc="upper right", fontsize=9)
+    ax.grid(axis="y", alpha=0.3)

--- a/exps/attn/sparse/bench_sparse_analysis/_common.py
+++ b/exps/attn/sparse/bench_sparse_analysis/_common.py
@@ -25,6 +25,29 @@ S_FULL = 32768
 TOPK_VALS = [32768, 16384, 8192, 4096, 2048]
 WARMUP, ITERS = 8, 20
 
+# ── Video-production scenarios (shared by Phase 6 & 8) ────────
+# qseqlen = kvseqlen/64, topk = kvseqlen/8
+VIDEO_SCENARIOS = [
+    # (kvseqlen, qseqlen, topk)
+    (32768, 512, 4096),
+    (65536, 1024, 8192),
+    (131072, 2048, 16384),
+    (262144, 4096, 32768),
+    (524288, 8192, 65536),
+]
+
+# ── Plot style (consistent across all phases) ─────────────────
+# Our kernels: warm/saturated colors
+COLOR_INDEX_SPARSE = (0.77, 0.34, 0.49)
+COLOR_BLOCK_SPARSE = (0.29, 0.57, 0.60)
+# External baselines: gray/dark
+COLOR_FLEXATTN = (0.45, 0.45, 0.45)
+COLOR_TRITON = (0.65, 0.65, 0.65)
+
+PLOT_BAR_WIDTH_RATIO = 0.8
+PLOT_BAR_ALPHA = 0.85
+PLOT_VALUE_FONTSIZE = 7
+
 _SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _BASE_OUT = os.path.join(_SCRIPT_DIR, "outs", "sparse_analysis")
 

--- a/exps/attn/sparse/bench_sparse_analysis/_common.py
+++ b/exps/attn/sparse/bench_sparse_analysis/_common.py
@@ -39,6 +39,7 @@ PHASES = [
     "5-scaling",
     "6-video-production",
     "7-outer-store-mode",
+    "8-baseline-comparison",
 ]
 
 

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -184,8 +184,10 @@ def _run_kbs1_ffa_is(S, topk, pass_type, device):
 def _run_kbs1_flexattn(S, topk, pass_type, device):
     """FlexAttention with sparse block mask."""
     import torch
+    import torch._functorch.config
     from torch.nn.attention.flex_attention import flex_attention
 
+    torch._functorch.config.donated_buffer = False
     q = torch.randn(1, NHQ, S, HD, dtype=torch.bfloat16, device=device)
     k = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
     v = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -21,10 +21,11 @@ Two sub-benchmarks organized by K block size:
       Passes: FWD, BWD (LoopK only — IS kbs=1 has no LoopQ)
 
   8b) kbs=128 (block-sparse):
-      FFA BlockSparse vs FFA IndexSparse(kbs=128) vs FlexAttention
+      FFA BlockSparse vs FFA IndexSparse(kbs=128) vs FlexAttention vs Triton Token-Sparse
       Passes: FWD, BWD_LoopK, BWD_LoopQ
 
-Config: nhq=128, nhk=1, hd=128, topk=2048 (fixed), sweep S=[32K..512K].
+Config: nhq=128, nhk=1, hd=128, video-production scenario
+        (qseqlen=kvseqlen/64, topk=kvseqlen/8), sweep kvseqlen=[32K..512K].
 """
 
 import gc
@@ -32,9 +33,17 @@ import os
 import sys
 
 from bench_sparse_analysis._common import (
+    COLOR_BLOCK_SPARSE,
+    COLOR_FLEXATTN,
+    COLOR_INDEX_SPARSE,
+    COLOR_TRITON,
     HD,
     NHK,
     NHQ,
+    PLOT_BAR_ALPHA,
+    PLOT_BAR_WIDTH_RATIO,
+    PLOT_VALUE_FONTSIZE,
+    VIDEO_SCENARIOS,
     _bench_kernel,
     _load_results,
     _out_dir,
@@ -50,15 +59,8 @@ from bench_sparse_analysis._common import (
 PHASE = "8-baseline-comparison"
 KBS_BLOCK = 128
 
-# Same scenario as Phase 6: qseqlen = kvseqlen/64, topk = kvseqlen/8
-SCENARIOS = [
-    # (kvseqlen, qseqlen, topk)
-    (32768, 512, 4096),
-    (65536, 1024, 8192),
-    (131072, 2048, 16384),
-    (262144, 4096, 32768),
-    (524288, 8192, 65536),
-]
+# Use shared video-production scenarios from _common
+SCENARIOS = VIDEO_SCENARIOS
 
 # 8a: kbs=1 (token-sparse)
 KBS1_METHODS = ["ffa_is", "flexattn", "triton"]
@@ -70,12 +72,13 @@ KBS1_LABELS = {
 }
 
 # 8b: kbs=128 (block-sparse)
-KBS128_METHODS = ["ffa_bs", "ffa_is128", "flexattn"]
+KBS128_METHODS = ["ffa_bs", "ffa_is128", "flexattn", "triton"]
 KBS128_PASSES = ["fwd", "bwd_loopk", "bwd_loopq"]
 KBS128_LABELS = {
     "ffa_bs": "FFA BlockSparse",
     "ffa_is128": "FFA IndexSparse (kbs=128)",
     "flexattn": "FlexAttention",
+    "triton": "Triton Token-Sparse",
 }
 
 
@@ -374,6 +377,50 @@ def _run_kbs128_flexattn(kvseqlen, qseqlen, topk, pass_type, device):
     return _run_kbs1_flexattn(kvseqlen, qseqlen, topk, pass_type, device)
 
 
+def _run_kbs128_triton(kvseqlen, qseqlen, topk, pass_type, device):
+    """Triton Token-Sparse in kbs=128 scenario (expand block indices to tokens)."""
+    import torch
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
+    from token_sparse_attn_triton import token_sparse_attn, token_sparse_fwd
+
+    q = torch.randn(qseqlen, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen, 1, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen, 1, HD, dtype=torch.bfloat16, device=device)
+
+    n_kv_blocks = kvseqlen // KBS_BLOCK
+    n_topk_blocks = topk // KBS_BLOCK
+    block_idx = (
+        torch.rand(qseqlen, n_kv_blocks, device=device)
+        .argsort(dim=1)[:, :n_topk_blocks]
+        .sort(dim=1)
+        .values
+    )
+    tri_indices = (
+        (block_idx.unsqueeze(-1) * KBS_BLOCK + torch.arange(KBS_BLOCK, device=device))
+        .reshape(qseqlen, topk)
+        .to(torch.int32)
+    )
+    is_bwd = pass_type != "fwd"
+
+    if is_bwd:
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o = token_sparse_attn(q, k, v, tri_indices)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            token_sparse_fwd(q, k, v, tri_indices)
+
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
+
+
 # ═══════════════════════════════════════════════════════════════
 #  Dispatch
 # ═══════════════════════════════════════════════════════════════
@@ -388,6 +435,7 @@ _KBS128_RUNNERS = {
     "ffa_bs": _run_kbs128_ffa_bs,
     "ffa_is128": _run_kbs128_ffa_is,
     "flexattn": _run_kbs128_flexattn,
+    "triton": _run_kbs128_triton,
 }
 
 
@@ -553,116 +601,77 @@ def _phase8_bench(force=False, rerun_filter=None):
         flush=True,
     )
 
-    # Correctness verification first
     if not _sanity_check(device):
         return
 
-    # --- 8a: kbs=1 ---
-    print("\n  " + "─" * 55, flush=True)
-    print("  8a) kbs=1: IndexSparse vs Baselines (FWD + BWD LoopK)", flush=True)
-    print("  " + "─" * 55, flush=True)
-    for kvseqlen, qseqlen, topk in SCENARIOS:
-        print(
-            f"  ── kvseqlen={kvseqlen // 1024}k, "
-            f"qseqlen={qseqlen}, topk={topk // 1024}k ──",
-            flush=True,
-        )
-        for pass_type in KBS1_PASSES:
-            for method in KBS1_METHODS:
-                key = f"kbs1/{pass_type}/{method}"
-                if not force and _has_entry(results, key, kvseqlen):
-                    d = results[key]
-                    idx = d["kvseqlen"].index(kvseqlen)
-                    tf = d["tflops"][idx]
-                    print(
-                        f"    {pass_type:10s} {method:10s}: " f"{tf:>7.1f} T (cached)",
-                        flush=True,
-                    )
-                    continue
+    def _run_group(prefix, methods, passes, runners, label):
+        print("\n  " + "─" * 55, flush=True)
+        print(f"  {label}", flush=True)
+        print("  " + "─" * 55, flush=True)
+        for kvseqlen, qseqlen, topk in SCENARIOS:
+            print(
+                f"  ── kvseqlen={kvseqlen // 1024}k, "
+                f"qseqlen={qseqlen}, topk={topk // 1024}k ──",
+                flush=True,
+            )
+            for pass_type in passes:
+                for method in methods:
+                    key = f"{prefix}/{pass_type}/{method}"
+                    if not force and _has_entry(results, key, kvseqlen):
+                        d = results[key]
+                        idx = d["kvseqlen"].index(kvseqlen)
+                        tf = d["tflops"][idx]
+                        print(
+                            f"    {pass_type:10s} {method:10s}: "
+                            f"{tf:>7.1f} T (cached)",
+                            flush=True,
+                        )
+                        continue
 
-                gc.collect()
-                torch.cuda.empty_cache()
-                try:
-                    runner = _KBS1_RUNNERS[method]
-                    tf, ms = runner(kvseqlen, qseqlen, topk, pass_type, device)
-                    _set_entry(results, key, kvseqlen, round(tf, 1), round(ms, 3))
-                    _save_results(PHASE, results)
-                    print(
-                        f"    {pass_type:10s} {method:10s}: "
-                        f"{tf:>7.1f} T  ({ms:.3f} ms)",
-                        flush=True,
-                    )
-                except torch.cuda.OutOfMemoryError:
-                    print(
-                        f"    {pass_type:10s} {method:10s}: OOM",
-                        flush=True,
-                    )
-                    _set_entry(results, key, kvseqlen, None, None)
-                    _save_results(PHASE, results)
+                    gc.collect()
                     torch.cuda.empty_cache()
-                except Exception as e:
-                    print(
-                        f"    {pass_type:10s} {method:10s}: ERR — {e}",
-                        flush=True,
-                    )
-                    _set_entry(results, key, kvseqlen, None, None)
-                    _save_results(PHASE, results)
-                    torch.cuda.empty_cache()
+                    try:
+                        tf, ms = runners[method](
+                            kvseqlen, qseqlen, topk, pass_type, device
+                        )
+                        _set_entry(results, key, kvseqlen, round(tf, 1), round(ms, 3))
+                        _save_results(PHASE, results)
+                        print(
+                            f"    {pass_type:10s} {method:10s}: "
+                            f"{tf:>7.1f} T  ({ms:.3f} ms)",
+                            flush=True,
+                        )
+                    except torch.cuda.OutOfMemoryError:
+                        print(
+                            f"    {pass_type:10s} {method:10s}: OOM",
+                            flush=True,
+                        )
+                        _set_entry(results, key, kvseqlen, None, None)
+                        _save_results(PHASE, results)
+                        torch.cuda.empty_cache()
+                    except Exception as e:
+                        print(
+                            f"    {pass_type:10s} {method:10s}: ERR — {e}",
+                            flush=True,
+                        )
+                        _set_entry(results, key, kvseqlen, None, None)
+                        _save_results(PHASE, results)
+                        torch.cuda.empty_cache()
 
-    # --- 8b: kbs=128 ---
-    print("\n  " + "─" * 55, flush=True)
-    print(
-        f"  8b) kbs={KBS_BLOCK}: BS/IS vs Baselines " f"(FWD + BWD LoopK + BWD LoopQ)",
-        flush=True,
+    _run_group(
+        "kbs1",
+        KBS1_METHODS,
+        KBS1_PASSES,
+        _KBS1_RUNNERS,
+        "8a) kbs=1: IndexSparse vs Baselines (FWD + BWD LoopK)",
     )
-    print("  " + "─" * 55, flush=True)
-    for kvseqlen, qseqlen, topk in SCENARIOS:
-        print(
-            f"  ── kvseqlen={kvseqlen // 1024}k, "
-            f"qseqlen={qseqlen}, topk={topk // 1024}k ──",
-            flush=True,
-        )
-        for pass_type in KBS128_PASSES:
-            for method in KBS128_METHODS:
-                key = f"kbs128/{pass_type}/{method}"
-                if not force and _has_entry(results, key, kvseqlen):
-                    d = results[key]
-                    idx = d["kvseqlen"].index(kvseqlen)
-                    tf = d["tflops"][idx]
-                    print(
-                        f"    {pass_type:10s} {method:10s}: " f"{tf:>7.1f} T (cached)",
-                        flush=True,
-                    )
-                    continue
-
-                gc.collect()
-                torch.cuda.empty_cache()
-                try:
-                    runner = _KBS128_RUNNERS[method]
-                    tf, ms = runner(kvseqlen, qseqlen, topk, pass_type, device)
-                    _set_entry(results, key, kvseqlen, round(tf, 1), round(ms, 3))
-                    _save_results(PHASE, results)
-                    print(
-                        f"    {pass_type:10s} {method:10s}: "
-                        f"{tf:>7.1f} T  ({ms:.3f} ms)",
-                        flush=True,
-                    )
-                except torch.cuda.OutOfMemoryError:
-                    print(
-                        f"    {pass_type:10s} {method:10s}: OOM",
-                        flush=True,
-                    )
-                    _set_entry(results, key, kvseqlen, None, None)
-                    _save_results(PHASE, results)
-                    torch.cuda.empty_cache()
-                except Exception as e:
-                    print(
-                        f"    {pass_type:10s} {method:10s}: ERR — {e}",
-                        flush=True,
-                    )
-                    _set_entry(results, key, kvseqlen, None, None)
-                    _save_results(PHASE, results)
-                    torch.cuda.empty_cache()
+    _run_group(
+        "kbs128",
+        KBS128_METHODS,
+        KBS128_PASSES,
+        _KBS128_RUNNERS,
+        f"8b) kbs={KBS_BLOCK}: BS/IS vs Baselines (FWD + BWD LoopK + BWD LoopQ)",
+    )
 
     print(f"\n[{_ts()}] Phase 8 done.", flush=True)
 
@@ -673,10 +682,10 @@ def _phase8_bench(force=False, rerun_filter=None):
 
 
 def _phase8_plot():
-    """Generate Phase-6 style grouped bar charts: 2 figures (kbs=1, kbs=128).
+    """Generate Phase-6 style grouped bar charts using _common plot constants.
 
-    Each figure has subplots for each pass (FWD, BWD, etc.), with grouped bars
-    per kvseqlen, one bar per method. TFLOPS on y-axis, kvseqlen on x-axis.
+    Two figures: phase8a_kbs1.png and phase8b_kbs128.png.
+    Colors: our kernels use warm/saturated from _common; baselines use grey/dark.
     """
     import matplotlib
 
@@ -696,153 +705,95 @@ def _phase8_plot():
     x = np.arange(len(kvseqlens))
     x_labels = [f"{kv // 1024}K\n(q={kv // 64}, top={kv // 8192}K)" for kv in kvseqlens]
 
+    def _plot_figure(fig_id, prefix, plot_defs, pass_defs, title):
+        """Shared plotting logic for both 8a and 8b."""
+        n_cols = len(pass_defs)
+        fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
+        if n_cols == 1:
+            axes = [axes]
+
+        for col_idx, (pid, pname) in enumerate(pass_defs):
+            ax = axes[col_idx]
+            n_m = len(plot_defs)
+            bw = PLOT_BAR_WIDTH_RATIO / n_m
+            for i, (mid, lbl, col) in enumerate(plot_defs):
+                key = f"{prefix}/{pid}/{mid}"
+                d = results.get(key, {})
+                vals = []
+                for kv in kvseqlens:
+                    if kv in d.get("kvseqlen", []):
+                        idx = d["kvseqlen"].index(kv)
+                        v = d["tflops"][idx] if d["tflops"][idx] else 0
+                    else:
+                        v = 0
+                    vals.append(v)
+                off = (i - n_m / 2 + 0.5) * bw
+                bars = ax.bar(
+                    x + off,
+                    vals,
+                    width=bw,
+                    label=lbl,
+                    color=col,
+                    edgecolor="white",
+                    linewidth=0.5,
+                    alpha=PLOT_BAR_ALPHA,
+                )
+                for bar, v in zip(bars, vals):
+                    if v > 0:
+                        ax.text(
+                            bar.get_x() + bar.get_width() / 2,
+                            bar.get_height() + 5,
+                            f"{v:.0f}",
+                            ha="center",
+                            va="bottom",
+                            fontsize=PLOT_VALUE_FONTSIZE,
+                            fontweight="bold",
+                        )
+
+            ax.set_title(pname, fontsize=13, fontweight="bold")
+            ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
+            ax.set_ylabel("TFLOPS", fontsize=12)
+            ax.set_xticks(x)
+            ax.set_xticklabels(x_labels, fontsize=9)
+            ax.tick_params(axis="y", labelsize=11)
+            ax.legend(loc="upper right", fontsize=9)
+            ax.grid(axis="y", alpha=0.3)
+
+        fig.suptitle(title, fontsize=13, fontweight="bold", y=1.02)
+        plt.tight_layout()
+        path = os.path.join(out, f"{fig_id}.png")
+        fig.savefig(path, dpi=180, bbox_inches="tight")
+        plt.close()
+        print(f"  Saved: {path}", flush=True)
+
     # ── 8a) kbs=1 ──
-    KBS1_PLOT = [
-        ("ffa_is", "FFA IndexSparse", (0.85, 0.25, 0.25)),
-        ("flexattn", "FlexAttention", (0.30, 0.70, 0.35)),
-        ("triton", "Triton Token-Sparse", (0.25, 0.45, 0.80)),
-    ]
-    KBS1_PASS_LABELS = [("fwd", "FWD"), ("bwd", "BWD (LoopK)")]
-
-    n_cols = len(KBS1_PASS_LABELS)
-    fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
-    if n_cols == 1:
-        axes = [axes]
-
-    for col_idx, (pid, pname) in enumerate(KBS1_PASS_LABELS):
-        ax = axes[col_idx]
-        n_m = len(KBS1_PLOT)
-        bw = 0.8 / n_m
-        for i, (mid, lbl, col) in enumerate(KBS1_PLOT):
-            key = f"kbs1/{pid}/{mid}"
-            d = results.get(key, {})
-            vals = []
-            for kv in kvseqlens:
-                if kv in d.get("kvseqlen", []):
-                    idx = d["kvseqlen"].index(kv)
-                    v = d["tflops"][idx] if d["tflops"][idx] else 0
-                else:
-                    v = 0
-                vals.append(v)
-            off = (i - n_m / 2 + 0.5) * bw
-            bars = ax.bar(
-                x + off,
-                vals,
-                width=bw,
-                label=lbl,
-                color=col,
-                edgecolor="white",
-                linewidth=0.5,
-                alpha=0.85,
-            )
-            for bar, v in zip(bars, vals):
-                if v > 0:
-                    ax.text(
-                        bar.get_x() + bar.get_width() / 2,
-                        bar.get_height() + 5,
-                        f"{v:.0f}",
-                        ha="center",
-                        va="bottom",
-                        fontsize=7,
-                        fontweight="bold",
-                    )
-
-        ax.set_title(pname, fontsize=13, fontweight="bold")
-        ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
-        ax.set_ylabel("TFLOPS", fontsize=12)
-        ax.set_xticks(x)
-        ax.set_xticklabels(x_labels, fontsize=9)
-        ax.tick_params(axis="y", labelsize=11)
-        ax.legend(loc="upper right", fontsize=9)
-        ax.grid(axis="y", alpha=0.3)
-
-    fig.suptitle(
+    _plot_figure(
+        "phase8a_kbs1",
+        "kbs1",
+        [
+            ("ffa_is", "FFA IndexSparse", COLOR_INDEX_SPARSE),
+            ("flexattn", "FlexAttention", COLOR_FLEXATTN),
+            ("triton", "Triton Token-Sparse", COLOR_TRITON),
+        ],
+        [("fwd", "FWD"), ("bwd", "BWD (LoopK)")],
         "Phase 8a: Token-Sparse Baseline (kbs=1)\n"
         f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
-        fontsize=13,
-        fontweight="bold",
-        y=1.02,
     )
-    plt.tight_layout()
-    path = os.path.join(out, "phase8a_kbs1.png")
-    fig.savefig(path, dpi=180, bbox_inches="tight")
-    plt.close()
-    print(f"  Saved: {path}", flush=True)
 
     # ── 8b) kbs=128 ──
-    KBS128_PLOT = [
-        ("ffa_bs", "FFA BlockSparse", (0.29, 0.57, 0.60)),
-        ("ffa_is128", "FFA IndexSparse (kbs=128)", (0.85, 0.45, 0.20)),
-        ("flexattn", "FlexAttention", (0.30, 0.70, 0.35)),
-    ]
-    KBS128_PASS_LABELS = [
-        ("fwd", "FWD"),
-        ("bwd_loopk", "BWD LoopK"),
-        ("bwd_loopq", "BWD LoopQ"),
-    ]
-
-    n_cols = len(KBS128_PASS_LABELS)
-    fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
-
-    for col_idx, (pid, pname) in enumerate(KBS128_PASS_LABELS):
-        ax = axes[col_idx]
-        n_m = len(KBS128_PLOT)
-        bw = 0.8 / n_m
-        for i, (mid, lbl, col) in enumerate(KBS128_PLOT):
-            key = f"kbs128/{pid}/{mid}"
-            d = results.get(key, {})
-            vals = []
-            for kv in kvseqlens:
-                if kv in d.get("kvseqlen", []):
-                    idx = d["kvseqlen"].index(kv)
-                    v = d["tflops"][idx] if d["tflops"][idx] else 0
-                else:
-                    v = 0
-                vals.append(v)
-            off = (i - n_m / 2 + 0.5) * bw
-            bars = ax.bar(
-                x + off,
-                vals,
-                width=bw,
-                label=lbl,
-                color=col,
-                edgecolor="white",
-                linewidth=0.5,
-                alpha=0.85,
-            )
-            for bar, v in zip(bars, vals):
-                if v > 0:
-                    ax.text(
-                        bar.get_x() + bar.get_width() / 2,
-                        bar.get_height() + 5,
-                        f"{v:.0f}",
-                        ha="center",
-                        va="bottom",
-                        fontsize=7,
-                        fontweight="bold",
-                    )
-
-        ax.set_title(pname, fontsize=13, fontweight="bold")
-        ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
-        ax.set_ylabel("TFLOPS", fontsize=12)
-        ax.set_xticks(x)
-        ax.set_xticklabels(x_labels, fontsize=9)
-        ax.tick_params(axis="y", labelsize=11)
-        ax.legend(loc="upper right", fontsize=9)
-        ax.grid(axis="y", alpha=0.3)
-
-    fig.suptitle(
+    _plot_figure(
+        "phase8b_kbs128",
+        "kbs128",
+        [
+            ("ffa_bs", "FFA BlockSparse", COLOR_BLOCK_SPARSE),
+            ("ffa_is128", "FFA IndexSparse (kbs=128)", COLOR_INDEX_SPARSE),
+            ("flexattn", "FlexAttention", COLOR_FLEXATTN),
+            ("triton", "Triton Token-Sparse", COLOR_TRITON),
+        ],
+        [("fwd", "FWD"), ("bwd_loopk", "BWD LoopK"), ("bwd_loopq", "BWD LoopQ")],
         f"Phase 8b: Block-Sparse Baseline (kbs={KBS_BLOCK})\n"
         f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
-        fontsize=13,
-        fontweight="bold",
-        y=1.02,
     )
-    plt.tight_layout()
-    path = os.path.join(out, "phase8b_kbs128.png")
-    fig.savefig(path, dpi=180, bbox_inches="tight")
-    plt.close()
-    print(f"  Saved: {path}", flush=True)
 
     # Summary tables
     print("\n  " + "─" * 60)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -1,0 +1,548 @@
+# Copyright (c) 2025-2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase 8: Baseline Comparison — FFA IndexSparse/BlockSparse vs external kernels.
+
+Compare MagiAttention sparse kernels against publicly available baselines:
+  - FlexAttention: PyTorch flex_attention + block_mask (Triton compiled)
+  - Triton Token-Sparse: Hand-written Triton MQA-optimized (tl.dot)
+
+Two sub-benchmarks:
+  8a) IndexSparse (kbs=1): token-level sparsity
+  8b) BlockSparse (kbs=128): block-level sparsity (FlexAttention only)
+
+Config: nhq=128, nhk=1, hd=128, topk=2048 (fixed), sweep S=[32K..512K].
+Passes: FWD, BWD.
+"""
+
+import gc
+import os
+import sys
+
+from bench_sparse_analysis._common import (
+    HD,
+    NHK,
+    NHQ,
+    _bench_kernel,
+    _load_results,
+    _out_dir,
+    _save_results,
+    _set_gpu,
+    _ts,
+)
+
+# ═══════════════════════════════════════════════════════════════
+#  Constants
+# ═══════════════════════════════════════════════════════════════
+
+PHASE = "8-baseline-comparison"
+TOPK = 2048
+KBS_BLOCK = 128
+SEQLEN_VALS = [32768, 65536, 131072, 262144, 524288]
+PASSES = ["fwd", "bwd"]
+
+# Index Sparse methods (kbs=1)
+IS_METHODS = ["ffa_index_sparse", "flexattention", "triton_token_sparse"]
+IS_METHOD_LABELS = {
+    "ffa_index_sparse": "FFA IndexSparse",
+    "flexattention": "FlexAttention",
+    "triton_token_sparse": "Triton Token-Sparse",
+}
+
+# Block Sparse methods (kbs=128)
+BS_METHODS = ["ffa_block_sparse", "flexattention"]
+BS_METHOD_LABELS = {
+    "ffa_block_sparse": "FFA BlockSparse",
+    "flexattention": "FlexAttention",
+}
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Helpers
+# ═══════════════════════════════════════════════════════════════
+
+
+def _calc_sparse_flops(S, topk, is_bwd):
+    fwd = 4 * S * topk * NHQ * HD
+    return fwd * 2.5 if is_bwd else fwd
+
+
+def _build_index_sparse_indices(S, topk, device):
+    """(S, NHK, topk) int32 — random per-Q-position token indices."""
+    import torch
+
+    idx = torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
+    idx = idx.sort(dim=1).values
+    return idx.unsqueeze(1).expand(-1, NHK, -1).contiguous()
+
+
+def _build_flex_block_mask(S, topk, device):
+    """FlexAttention block_mask for sparse pattern (128x128 blocks)."""
+    import torch
+    from torch.nn.attention.flex_attention import create_block_mask
+
+    FLEX_BLOCK = 128
+    num_q_blocks = S // FLEX_BLOCK
+    num_kv_blocks = S // FLEX_BLOCK
+    kv_blocks_needed = min((topk + FLEX_BLOCK - 1) // FLEX_BLOCK, num_kv_blocks)
+
+    selected = torch.rand(num_q_blocks, num_kv_blocks, device=device).argsort(dim=1)[
+        :, :kv_blocks_needed
+    ]
+    mask_dense = torch.zeros(
+        num_q_blocks, num_kv_blocks, dtype=torch.bool, device=device
+    )
+    mask_dense.scatter_(1, selected, True)
+
+    def sparse_mask_mod(b_idx, h_idx, q_idx, kv_idx):
+        q_block = q_idx // FLEX_BLOCK
+        kv_block = kv_idx // FLEX_BLOCK
+        return mask_dense[q_block, kv_block]
+
+    return create_block_mask(
+        sparse_mask_mod, B=None, H=None, Q_LEN=S, KV_LEN=S, device=device
+    )
+
+
+def _build_block_sparse_indices(S, topk, device):
+    """(S, NHK, n_topk_blocks) int32 — block-level indices for FFA BlockSparse."""
+    import torch
+
+    n_kv_blocks = S // KBS_BLOCK
+    n_topk_blocks = topk // KBS_BLOCK
+    if n_topk_blocks >= n_kv_blocks:
+        idx = torch.arange(n_kv_blocks, dtype=torch.int32, device=device)
+        return idx.unsqueeze(0).unsqueeze(0).expand(S, NHK, -1).contiguous()
+    idx = (
+        torch.rand(S, n_kv_blocks, device=device)
+        .argsort(dim=1)[:, :n_topk_blocks]
+        .sort(dim=1)
+        .values
+    )
+    return idx.unsqueeze(1).expand(-1, NHK, -1).to(torch.int32).contiguous()
+
+
+def _has_entry(results, key, S):
+    d = results.get(key, {})
+    if not d or "seqlen" not in d:
+        return False
+    try:
+        idx = d["seqlen"].index(S)
+        return d["tflops"][idx] is not None
+    except (ValueError, IndexError):
+        return False
+
+
+def _set_entry(results, key, S, tflops, ms):
+    if key not in results:
+        results[key] = {"seqlen": [], "tflops": [], "ms": []}
+    d = results[key]
+    if S in d["seqlen"]:
+        idx = d["seqlen"].index(S)
+        d["tflops"][idx] = tflops
+        d["ms"][idx] = ms
+    else:
+        d["seqlen"].append(S)
+        d["tflops"].append(tflops)
+        d["ms"].append(ms)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Index Sparse Runners
+# ═══════════════════════════════════════════════════════════════
+
+
+def _run_ffa_index_sparse(S, topk, is_bwd, device):
+    import torch
+
+    from magi_attention.functional import flex_flash_attn_func
+
+    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    indices = _build_index_sparse_indices(S, topk, device)
+
+    kw = dict(
+        index_sparse_indices=indices,
+        q_block_size=1,
+        sparse_k_block_size=1,
+        pack_gqa=True,
+        disable_fwd_atomic_reduction=True,
+    )
+
+    if is_bwd:
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o, *_ = flex_flash_attn_func(q, k, v, **kw)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            flex_flash_attn_func(q, k, v, **kw)
+
+    flops = _calc_sparse_flops(S, topk, is_bwd)
+    return _bench_kernel(run_fn, flops, device)
+
+
+def _run_flexattention(S, topk, is_bwd, device):
+    import torch
+    from torch.nn.attention.flex_attention import flex_attention
+
+    q = torch.randn(1, NHQ, S, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
+    block_mask = _build_flex_block_mask(S, topk, device)
+    _flex_fn = torch.compile(flex_attention)
+
+    if is_bwd:
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o = _flex_fn(q, k, v, block_mask=block_mask, enable_gqa=True)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            _flex_fn(q, k, v, block_mask=block_mask, enable_gqa=True)
+
+    flops = _calc_sparse_flops(S, topk, is_bwd)
+    return _bench_kernel(run_fn, flops, device)
+
+
+def _run_triton_token_sparse(S, topk, is_bwd, device):
+    import torch
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
+    from token_sparse_attn_triton import token_sparse_attn, token_sparse_fwd
+
+    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(S, 1, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(S, 1, HD, dtype=torch.bfloat16, device=device)
+    tri_indices = (
+        torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
+        .sort(dim=1)
+        .values
+    )
+
+    if is_bwd:
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o = token_sparse_attn(q, k, v, tri_indices)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            token_sparse_fwd(q, k, v, tri_indices)
+
+    flops = _calc_sparse_flops(S, topk, is_bwd)
+    return _bench_kernel(run_fn, flops, device)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Block Sparse Runners
+# ═══════════════════════════════════════════════════════════════
+
+
+def _run_ffa_block_sparse(S, topk, is_bwd, device):
+    import torch
+
+    from magi_attention.functional import flex_flash_attn_func
+    from magi_attention.utils.sparse_utils import generate_ranges_from_topk_indices
+
+    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    indices = _build_block_sparse_indices(S, topk, device)
+
+    ia_3d = indices.permute(1, 0, 2).contiguous()
+    q_ranges, k_ranges = generate_ranges_from_topk_indices(
+        ia_3d, block_m=1, block_n=KBS_BLOCK, num_k_blocks=S // KBS_BLOCK
+    )
+    atm = torch.zeros(q_ranges.size(0), dtype=torch.int32, device=device)
+
+    kw = dict(
+        q_ranges=q_ranges,
+        k_ranges=k_ranges,
+        attn_type_map=atm,
+        pack_gqa=True,
+        disable_fwd_atomic_reduction=True,
+    )
+
+    if is_bwd:
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o, *_ = flex_flash_attn_func(q, k, v, **kw)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            flex_flash_attn_func(q, k, v, **kw)
+
+    flops = _calc_sparse_flops(S, topk, is_bwd)
+    return _bench_kernel(run_fn, flops, device)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Dispatch
+# ═══════════════════════════════════════════════════════════════
+
+_RUNNERS = {
+    "ffa_index_sparse": _run_ffa_index_sparse,
+    "ffa_block_sparse": _run_ffa_block_sparse,
+    "flexattention": _run_flexattention,
+    "triton_token_sparse": _run_triton_token_sparse,
+}
+
+
+# ═══════════════════════════════════════════════════════════════
+#  --exp
+# ═══════════════════════════════════════════════════════════════
+
+
+def _phase8_bench(force=False, rerun_filter=None):
+    import torch
+
+    results = _load_results(PHASE)
+    gpu = _set_gpu()
+    device = f"cuda:{gpu}"
+
+    print(f"[{_ts()}] Phase 8: Baseline Comparison (gpu{gpu})", flush=True)
+    print(
+        f"  nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, "
+        f"S=[{','.join(f'{s // 1024}k' for s in SEQLEN_VALS)}]",
+        flush=True,
+    )
+    print(f"  Passes: {PASSES}\n", flush=True)
+
+    # --- 8a: IndexSparse ---
+    print("  " + "─" * 50, flush=True)
+    print("  8a) IndexSparse (kbs=1) vs Baselines", flush=True)
+    print("  " + "─" * 50, flush=True)
+    for pass_type in PASSES:
+        is_bwd = pass_type == "bwd"
+        for method in IS_METHODS:
+            for S in SEQLEN_VALS:
+                key = f"is/{pass_type}/{method}"
+                if rerun_filter and (pass_type, method, S) not in rerun_filter:
+                    continue
+                if not force and _has_entry(results, key, S):
+                    d = results[key]
+                    idx = d["seqlen"].index(S)
+                    tf = d["tflops"][idx]
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"{tf:>7.1f} T (cached)",
+                        flush=True,
+                    )
+                    continue
+
+                gc.collect()
+                torch.cuda.empty_cache()
+                try:
+                    runner = _RUNNERS[method]
+                    tf, ms = runner(S, TOPK, is_bwd, device)
+                    _set_entry(results, key, S, round(tf, 1), round(ms, 3))
+                    _save_results(PHASE, results)
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"{tf:>7.1f} T  ({ms:.3f} ms)",
+                        flush=True,
+                    )
+                except torch.cuda.OutOfMemoryError:
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: OOM",
+                        flush=True,
+                    )
+                    _set_entry(results, key, S, None, None)
+                    _save_results(PHASE, results)
+                    torch.cuda.empty_cache()
+                except Exception as e:
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"ERROR — {e}",
+                        flush=True,
+                    )
+                    _set_entry(results, key, S, None, None)
+                    _save_results(PHASE, results)
+                    torch.cuda.empty_cache()
+
+    # --- 8b: BlockSparse ---
+    print("\n  " + "─" * 50, flush=True)
+    print(f"  8b) BlockSparse (kbs={KBS_BLOCK}) vs Baselines", flush=True)
+    print(f"  {'─' * 50}", flush=True)
+    for pass_type in PASSES:
+        is_bwd = pass_type == "bwd"
+        for method in BS_METHODS:
+            for S in SEQLEN_VALS:
+                key = f"bs/{pass_type}/{method}"
+                if rerun_filter and (pass_type, method, S) not in rerun_filter:
+                    continue
+                if not force and _has_entry(results, key, S):
+                    d = results[key]
+                    idx = d["seqlen"].index(S)
+                    tf = d["tflops"][idx]
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"{tf:>7.1f} T (cached)",
+                        flush=True,
+                    )
+                    continue
+
+                gc.collect()
+                torch.cuda.empty_cache()
+                try:
+                    runner = _RUNNERS[method]
+                    tf, ms = runner(S, TOPK, is_bwd, device)
+                    _set_entry(results, key, S, round(tf, 1), round(ms, 3))
+                    _save_results(PHASE, results)
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"{tf:>7.1f} T  ({ms:.3f} ms)",
+                        flush=True,
+                    )
+                except torch.cuda.OutOfMemoryError:
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: OOM",
+                        flush=True,
+                    )
+                    _set_entry(results, key, S, None, None)
+                    _save_results(PHASE, results)
+                    torch.cuda.empty_cache()
+                except Exception as e:
+                    print(
+                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"ERROR — {e}",
+                        flush=True,
+                    )
+                    _set_entry(results, key, S, None, None)
+                    _save_results(PHASE, results)
+                    torch.cuda.empty_cache()
+
+    print(f"\n[{_ts()}] Phase 8 done.", flush=True)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  --plot
+# ═══════════════════════════════════════════════════════════════
+
+
+def _phase8_plot():
+    import matplotlib.pyplot as plt
+
+    results = _load_results(PHASE)
+    if not results:
+        print("  [WARN] No results found. Run --exp first.")
+        return
+
+    out = _out_dir(PHASE)
+    os.makedirs(out, exist_ok=True)
+
+    for sub, methods, labels in [
+        ("is", IS_METHODS, IS_METHOD_LABELS),
+        ("bs", BS_METHODS, BS_METHOD_LABELS),
+    ]:
+        for pass_type in PASSES:
+            fig, ax = plt.subplots(figsize=(10, 6))
+            has_data = False
+            for method in methods:
+                key = f"{sub}/{pass_type}/{method}"
+                d = results.get(key)
+                if not d:
+                    continue
+                seqlens = d["seqlen"]
+                tflops = d["tflops"]
+                valid = [(s, t) for s, t in zip(seqlens, tflops) if t is not None]
+                if not valid:
+                    continue
+                xs, ys = zip(*valid)
+                ax.plot(
+                    [x // 1024 for x in xs],
+                    ys,
+                    marker="o",
+                    label=labels[method],
+                    linewidth=2,
+                )
+                has_data = True
+
+            if not has_data:
+                plt.close(fig)
+                continue
+
+            kbs_label = "kbs=1" if sub == "is" else f"kbs={KBS_BLOCK}"
+            title = (
+                f"Sparse Attention {pass_type.upper()} — {kbs_label}\n"
+                f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}"
+            )
+            ax.set_title(title)
+            ax.set_xlabel("Sequence Length (K)")
+            ax.set_ylabel("Effective Sparse TFLOPS/s")
+            ax.legend()
+            ax.grid(True, alpha=0.3)
+            ax.set_xscale("log", base=2)
+            ax.set_xticks([s // 1024 for s in SEQLEN_VALS])
+            ax.get_xaxis().set_major_formatter(
+                plt.FuncFormatter(lambda x, _: f"{int(x)}K")
+            )
+
+            fname = f"{sub}_{pass_type}.png"
+            fig.savefig(os.path.join(out, fname), dpi=150, bbox_inches="tight")
+            plt.close(fig)
+            print(f"  Saved: {os.path.join(out, fname)}", flush=True)
+
+    # Summary table
+    print("\n  " + "─" * 60)
+    print("  Summary Table (TFLOPS)")
+    print("  " + "─" * 60)
+    for sub, methods, labels in [
+        ("is", IS_METHODS, IS_METHOD_LABELS),
+        ("bs", BS_METHODS, BS_METHOD_LABELS),
+    ]:
+        kbs_label = "kbs=1" if sub == "is" else f"kbs={KBS_BLOCK}"
+        for pass_type in PASSES:
+            print(f"\n  {pass_type.upper()} ({kbs_label}):")
+            header = f"  {'S':>6s}"
+            for m in methods:
+                header += f"  {labels[m]:>20s}"
+            print(header)
+            for S in SEQLEN_VALS:
+                row = f"  {S // 1024:>5d}k"
+                for m in methods:
+                    key = f"{sub}/{pass_type}/{m}"
+                    d = results.get(key, {})
+                    if d and S in d.get("seqlen", []):
+                        idx = d["seqlen"].index(S)
+                        tf = d["tflops"][idx]
+                        row += f"  {tf:>20.1f}" if tf else f"  {'—':>20s}"
+                    else:
+                        row += f"  {'—':>20s}"
+                print(row)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -290,6 +290,8 @@ def _run_ffa_block_sparse(S, topk, is_bwd, device):
         k_ranges=k_ranges,
         attn_type_map=atm,
         pack_gqa=True,
+        block_sparse=True,
+        range_merge=True,
         disable_fwd_atomic_reduction=True,
     )
 
@@ -325,6 +327,152 @@ _RUNNERS = {
 
 
 # ═══════════════════════════════════════════════════════════════
+#  Correctness Verification
+# ═══════════════════════════════════════════════════════════════
+
+
+def _ref_token_sparse_attn(q, k, v, indices, sm_scale=None):
+    """Naive reference: per-query gather topk KV → softmax → output."""
+    import torch
+
+    S, Hq, D = q.shape
+    if sm_scale is None:
+        sm_scale = 1.0 / (D**0.5)
+    q_f = q.float()
+    k_f = k.squeeze(1).float()
+    v_f = v.squeeze(1).float()
+    o = torch.zeros_like(q_f)
+    for i in range(min(S, 64)):
+        idx = indices[i].long()
+        ki = k_f[idx]
+        vi = v_f[idx]
+        qi = q_f[i]
+        scores = (qi @ ki.T) * sm_scale
+        weights = torch.softmax(scores, dim=-1)
+        o[i] = weights @ vi
+    return o[:64].to(q.dtype)
+
+
+def _sanity_check(device):
+    """Verify correctness of all methods at small scale before benchmarking."""
+    import torch
+
+    from magi_attention.functional import flex_flash_attn_func
+    from magi_attention.utils.sparse_utils import generate_ranges_from_topk_indices
+
+    S_ck, topk_ck = 512, 128
+    torch.manual_seed(42)
+    q = torch.randn(S_ck, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
+
+    # Shared indices for fair comparison
+    indices_2d = (
+        torch.randint(0, S_ck, (S_ck, topk_ck), device=device, dtype=torch.int32)
+        .sort(dim=1)
+        .values
+    )
+    # Reference (first 64 rows only for speed)
+    ref = _ref_token_sparse_attn(q, k, v, indices_2d)
+
+    results = {}
+
+    # 1. FFA IndexSparse
+    is_indices = indices_2d.unsqueeze(1).expand(-1, NHK, -1).contiguous()
+    ffa_out, *_ = flex_flash_attn_func(
+        q,
+        k,
+        v,
+        index_sparse_indices=is_indices,
+        q_block_size=1,
+        sparse_k_block_size=1,
+        pack_gqa=True,
+        disable_fwd_atomic_reduction=True,
+    )
+    err = (ffa_out[:64].float() - ref.float()).abs().max().item()
+    results["ffa_index_sparse"] = err
+
+    # 2. FFA BlockSparse (kbs=128)
+    n_kv_blocks = S_ck // KBS_BLOCK
+    n_topk_blocks = topk_ck // KBS_BLOCK
+    bs_idx = (
+        torch.rand(S_ck, n_kv_blocks, device=device)
+        .argsort(dim=1)[:, :n_topk_blocks]
+        .sort(dim=1)
+        .values.unsqueeze(1)
+        .expand(-1, NHK, -1)
+        .to(torch.int32)
+        .contiguous()
+    )
+    ia_3d = bs_idx.permute(1, 0, 2).contiguous()
+    q_ranges, k_ranges = generate_ranges_from_topk_indices(
+        ia_3d, block_m=1, block_n=KBS_BLOCK, num_k_blocks=n_kv_blocks
+    )
+    atm = torch.zeros(q_ranges.size(0), dtype=torch.int32, device=device)
+    bs_out, *_ = flex_flash_attn_func(
+        q,
+        k,
+        v,
+        q_ranges=q_ranges,
+        k_ranges=k_ranges,
+        attn_type_map=atm,
+        pack_gqa=True,
+        block_sparse=True,
+        range_merge=True,
+        disable_fwd_atomic_reduction=True,
+    )
+    # BS attends to DIFFERENT K positions (blocks of 128) so can't compare to ref directly.
+    # Just check it doesn't produce NaN/Inf and output shape is correct.
+    bs_ok = (
+        not torch.isnan(bs_out).any().item()
+        and not torch.isinf(bs_out).any().item()
+        and bs_out.shape == (S_ck, NHQ, HD)
+    )
+    results["ffa_block_sparse"] = 0.0 if bs_ok else float("inf")
+
+    # 3. FlexAttention
+    from torch.nn.attention.flex_attention import flex_attention
+
+    q_bhsd = q.unsqueeze(0).permute(0, 2, 1, 3)  # (1, NHQ, S, HD)
+    k_bhsd = k.unsqueeze(0).permute(0, 2, 1, 3)
+    v_bhsd = v.unsqueeze(0).permute(0, 2, 1, 3)
+    block_mask = _build_flex_block_mask(S_ck, topk_ck, device)
+    flex_fn = torch.compile(flex_attention)
+    flex_out = flex_fn(q_bhsd, k_bhsd, v_bhsd, block_mask=block_mask, enable_gqa=True)
+    flex_ok = (
+        not torch.isnan(flex_out).any().item()
+        and not torch.isinf(flex_out).any().item()
+        and flex_out.shape == (1, NHQ, S_ck, HD)
+    )
+    results["flexattention"] = 0.0 if flex_ok else float("inf")
+
+    # 4. Triton Token-Sparse
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
+    from token_sparse_attn_triton import token_sparse_fwd
+
+    tri_out = token_sparse_fwd(q, k, v, indices_2d)
+    err_tri = (tri_out[:64].float() - ref.float()).abs().max().item()
+    results["triton_token_sparse"] = err_tri
+
+    # Print results
+    print("  Correctness verification (S=512, topk=128):", flush=True)
+    all_pass = True
+    for method, val in results.items():
+        if val < 0.05:
+            status = "PASS"
+        elif val == 0.0:
+            status = "PASS (shape/nan check)"
+        else:
+            status = f"FAIL (max_err={val:.4f})"
+            all_pass = False
+        print(f"    {method:22s}: {status}", flush=True)
+
+    if not all_pass:
+        print("  [ERROR] Correctness check failed! Aborting.", flush=True)
+    return all_pass
+
+
+# ═══════════════════════════════════════════════════════════════
 #  --exp
 # ═══════════════════════════════════════════════════════════════
 
@@ -343,6 +491,10 @@ def _phase8_bench(force=False, rerun_filter=None):
         flush=True,
     )
     print(f"  Passes: {PASSES}\n", flush=True)
+
+    # Correctness verification first
+    if not _sanity_check(device):
+        return
 
     # --- 8a: IndexSparse ---
     print("  " + "─" * 50, flush=True)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -48,9 +48,17 @@ from bench_sparse_analysis._common import (
 # ═══════════════════════════════════════════════════════════════
 
 PHASE = "8-baseline-comparison"
-TOPK = 2048
 KBS_BLOCK = 128
-SEQLEN_VALS = [32768, 65536, 131072, 262144, 524288]
+
+# Same scenario as Phase 6: qseqlen = kvseqlen/64, topk = kvseqlen/8
+SCENARIOS = [
+    # (kvseqlen, qseqlen, topk)
+    (32768, 512, 4096),
+    (65536, 1024, 8192),
+    (131072, 2048, 16384),
+    (262144, 4096, 32768),
+    (524288, 8192, 65536),
+]
 
 # 8a: kbs=1 (token-sparse)
 KBS1_METHODS = ["ffa_is", "flexattn", "triton"]
@@ -76,19 +84,19 @@ KBS128_LABELS = {
 # ═══════════════════════════════════════════════════════════════
 
 
-def _calc_sparse_flops(S, topk, is_bwd):
-    fwd = 4 * S * topk * NHQ * HD
+def _calc_sparse_flops(qseqlen, topk, is_bwd):
+    fwd = 4 * qseqlen * topk * NHQ * HD
     return fwd * 2.5 if is_bwd else fwd
 
 
-def _build_flex_block_mask(S, topk, device):
-    """FlexAttention block_mask for sparse pattern (128x128 blocks)."""
+def _build_flex_block_mask(qseqlen, kvseqlen, topk, device):
+    """FlexAttention block_mask for sparse pattern (128x128 blocks), Q≠KV."""
     import torch
     from torch.nn.attention.flex_attention import create_block_mask
 
     FLEX_BLOCK = 128
-    num_q_blocks = S // FLEX_BLOCK
-    num_kv_blocks = S // FLEX_BLOCK
+    num_q_blocks = (qseqlen + FLEX_BLOCK - 1) // FLEX_BLOCK
+    num_kv_blocks = kvseqlen // FLEX_BLOCK
     kv_blocks_needed = min((topk + FLEX_BLOCK - 1) // FLEX_BLOCK, num_kv_blocks)
 
     selected = torch.rand(num_q_blocks, num_kv_blocks, device=device).argsort(dim=1)[
@@ -105,31 +113,31 @@ def _build_flex_block_mask(S, topk, device):
         return mask_dense[q_block, kv_block]
 
     return create_block_mask(
-        sparse_mask_mod, B=None, H=None, Q_LEN=S, KV_LEN=S, device=device
+        sparse_mask_mod, B=None, H=None, Q_LEN=qseqlen, KV_LEN=kvseqlen, device=device
     )
 
 
-def _has_entry(results, key, S):
+def _has_entry(results, key, kvseqlen):
     d = results.get(key, {})
-    if not d or "seqlen" not in d:
+    if not d or "kvseqlen" not in d:
         return False
     try:
-        idx = d["seqlen"].index(S)
+        idx = d["kvseqlen"].index(kvseqlen)
         return d["tflops"][idx] is not None
     except (ValueError, IndexError):
         return False
 
 
-def _set_entry(results, key, S, tflops, ms):
+def _set_entry(results, key, kvseqlen, tflops, ms):
     if key not in results:
-        results[key] = {"seqlen": [], "tflops": [], "ms": []}
+        results[key] = {"kvseqlen": [], "tflops": [], "ms": []}
     d = results[key]
-    if S in d["seqlen"]:
-        idx = d["seqlen"].index(S)
+    if kvseqlen in d["kvseqlen"]:
+        idx = d["kvseqlen"].index(kvseqlen)
         d["tflops"][idx] = tflops
         d["ms"][idx] = ms
     else:
-        d["seqlen"].append(S)
+        d["kvseqlen"].append(kvseqlen)
         d["tflops"].append(tflops)
         d["ms"].append(ms)
 
@@ -139,17 +147,17 @@ def _set_entry(results, key, S, tflops, ms):
 # ═══════════════════════════════════════════════════════════════
 
 
-def _run_kbs1_ffa_is(S, topk, pass_type, device):
+def _run_kbs1_ffa_is(kvseqlen, qseqlen, topk, pass_type, device):
     """FFA IndexSparse kbs=1. BWD always uses LoopK (no LoopQ for kbs=1)."""
     import torch
 
     from magi_attention.functional import flex_flash_attn_func
 
-    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    q = torch.randn(qseqlen, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
     indices = (
-        torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
+        torch.randint(0, kvseqlen, (qseqlen, topk), device=device, dtype=torch.int32)
         .sort(dim=1)
         .values.unsqueeze(1)
         .expand(-1, NHK, -1)
@@ -178,20 +186,20 @@ def _run_kbs1_ffa_is(S, topk, pass_type, device):
         def run_fn():
             flex_flash_attn_func(q, k, v, **kw)
 
-    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
 
 
-def _run_kbs1_flexattn(S, topk, pass_type, device):
+def _run_kbs1_flexattn(kvseqlen, qseqlen, topk, pass_type, device):
     """FlexAttention with sparse block mask."""
     import torch
     import torch._functorch.config
     from torch.nn.attention.flex_attention import flex_attention
 
     torch._functorch.config.donated_buffer = False
-    q = torch.randn(1, NHQ, S, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
-    block_mask = _build_flex_block_mask(S, topk, device)
+    q = torch.randn(1, NHQ, qseqlen, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(1, NHK, kvseqlen, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(1, NHK, kvseqlen, HD, dtype=torch.bfloat16, device=device)
+    block_mask = _build_flex_block_mask(qseqlen, kvseqlen, topk, device)
     _flex_fn = torch.compile(flex_attention)
     is_bwd = pass_type != "fwd"
 
@@ -210,21 +218,21 @@ def _run_kbs1_flexattn(S, topk, pass_type, device):
         def run_fn():
             _flex_fn(q, k, v, block_mask=block_mask, enable_gqa=True)
 
-    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
 
 
-def _run_kbs1_triton(S, topk, pass_type, device):
+def _run_kbs1_triton(kvseqlen, qseqlen, topk, pass_type, device):
     """Triton hand-written token-sparse kernel."""
     import torch
 
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
     from token_sparse_attn_triton import token_sparse_attn, token_sparse_fwd
 
-    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(S, 1, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(S, 1, HD, dtype=torch.bfloat16, device=device)
+    q = torch.randn(qseqlen, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen, 1, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen, 1, HD, dtype=torch.bfloat16, device=device)
     tri_indices = (
-        torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
+        torch.randint(0, kvseqlen, (qseqlen, topk), device=device, dtype=torch.int32)
         .sort(dim=1)
         .values
     )
@@ -245,7 +253,7 @@ def _run_kbs1_triton(S, topk, pass_type, device):
         def run_fn():
             token_sparse_fwd(q, k, v, tri_indices)
 
-    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -253,21 +261,21 @@ def _run_kbs1_triton(S, topk, pass_type, device):
 # ═══════════════════════════════════════════════════════════════
 
 
-def _run_kbs128_ffa_bs(S, topk, pass_type, device):
+def _run_kbs128_ffa_bs(kvseqlen, qseqlen, topk, pass_type, device):
     """FFA BlockSparse (q_ranges/k_ranges + block_sparse + range_merge)."""
     import torch
 
     from magi_attention.functional import flex_flash_attn_func
     from magi_attention.utils.sparse_utils import generate_ranges_from_topk_indices
 
-    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    q = torch.randn(qseqlen, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
 
-    n_kv_blocks = S // KBS_BLOCK
+    n_kv_blocks = kvseqlen // KBS_BLOCK
     n_topk_blocks = topk // KBS_BLOCK
     indices = (
-        torch.rand(S, n_kv_blocks, device=device)
+        torch.rand(qseqlen, n_kv_blocks, device=device)
         .argsort(dim=1)[:, :n_topk_blocks]
         .sort(dim=1)
         .values.unsqueeze(1)
@@ -308,23 +316,23 @@ def _run_kbs128_ffa_bs(S, topk, pass_type, device):
         def run_fn():
             flex_flash_attn_func(q, k, v, **kw)
 
-    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
 
 
-def _run_kbs128_ffa_is(S, topk, pass_type, device):
+def _run_kbs128_ffa_is(kvseqlen, qseqlen, topk, pass_type, device):
     """FFA IndexSparse with kbs=128 (index_sparse_indices with block indices)."""
     import torch
 
     from magi_attention.functional import flex_flash_attn_func
 
-    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    q = torch.randn(qseqlen, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen, NHK, HD, dtype=torch.bfloat16, device=device)
 
-    n_kv_blocks = S // KBS_BLOCK
+    n_kv_blocks = kvseqlen // KBS_BLOCK
     n_topk_blocks = topk // KBS_BLOCK
     indices = (
-        torch.rand(S, n_kv_blocks, device=device)
+        torch.rand(qseqlen, n_kv_blocks, device=device)
         .argsort(dim=1)[:, :n_topk_blocks]
         .sort(dim=1)
         .values.unsqueeze(1)
@@ -358,12 +366,12 @@ def _run_kbs128_ffa_is(S, topk, pass_type, device):
         def run_fn():
             flex_flash_attn_func(q, k, v, **kw)
 
-    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(qseqlen, topk, is_bwd), device)
 
 
-def _run_kbs128_flexattn(S, topk, pass_type, device):
-    """FlexAttention (same for kbs=128 group — block mask matches 128-block granularity)."""
-    return _run_kbs1_flexattn(S, topk, pass_type, device)
+def _run_kbs128_flexattn(kvseqlen, qseqlen, topk, pass_type, device):
+    """FlexAttention for kbs=128 group (same as kbs1 but different scenario)."""
+    return _run_kbs1_flexattn(kvseqlen, qseqlen, topk, pass_type, device)
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -417,14 +425,16 @@ def _sanity_check(device):
     from magi_attention.functional import flex_flash_attn_func
     from magi_attention.utils.sparse_utils import generate_ranges_from_topk_indices
 
-    S_ck, topk_ck = 512, 128
+    kvseqlen_ck, qseqlen_ck, topk_ck = 512, 64, 128
     torch.manual_seed(42)
-    q = torch.randn(S_ck, NHQ, HD, dtype=torch.bfloat16, device=device)
-    k = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
-    v = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
+    q = torch.randn(qseqlen_ck, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(kvseqlen_ck, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(kvseqlen_ck, NHK, HD, dtype=torch.bfloat16, device=device)
 
     indices_2d = (
-        torch.randint(0, S_ck, (S_ck, topk_ck), device=device, dtype=torch.int32)
+        torch.randint(
+            0, kvseqlen_ck, (qseqlen_ck, topk_ck), device=device, dtype=torch.int32
+        )
         .sort(dim=1)
         .values
     )
@@ -446,10 +456,10 @@ def _sanity_check(device):
     results["ffa_is_kbs1"] = (ffa_out[:64].float() - ref.float()).abs().max().item()
 
     # 2. FFA BlockSparse kbs=128
-    n_kv_blocks = S_ck // KBS_BLOCK
+    n_kv_blocks = kvseqlen_ck // KBS_BLOCK
     n_topk_blocks = topk_ck // KBS_BLOCK
     bs_idx = (
-        torch.rand(S_ck, n_kv_blocks, device=device)
+        torch.rand(qseqlen_ck, n_kv_blocks, device=device)
         .argsort(dim=1)[:, :n_topk_blocks]
         .sort(dim=1)
         .values.unsqueeze(1)
@@ -497,7 +507,7 @@ def _sanity_check(device):
     q_bhsd = q.unsqueeze(0).permute(0, 2, 1, 3)
     k_bhsd = k.unsqueeze(0).permute(0, 2, 1, 3)
     v_bhsd = v.unsqueeze(0).permute(0, 2, 1, 3)
-    block_mask = _build_flex_block_mask(S_ck, topk_ck, device)
+    block_mask = _build_flex_block_mask(qseqlen_ck, kvseqlen_ck, topk_ck, device)
     flex_fn = torch.compile(flex_attention)
     flex_out = flex_fn(q_bhsd, k_bhsd, v_bhsd, block_mask=block_mask, enable_gqa=True)
     flex_ok = not torch.isnan(flex_out).any() and not torch.isinf(flex_out).any()
@@ -511,7 +521,7 @@ def _sanity_check(device):
     results["triton"] = (tri_out[:64].float() - ref.float()).abs().max().item()
 
     # Print
-    print("  Correctness check (S=512, topk=128):", flush=True)
+    print("  Correctness check (kvseqlen=512, qseqlen=64, topk=128):", flush=True)
     all_pass = True
     for method, val in results.items():
         status = "PASS" if val < 0.05 else f"FAIL (err={val:.4f})"
@@ -537,8 +547,9 @@ def _phase8_bench(force=False, rerun_filter=None):
 
     print(f"[{_ts()}] Phase 8: Baseline Comparison (gpu{gpu})", flush=True)
     print(
-        f"  nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, "
-        f"S=[{','.join(f'{s // 1024}k' for s in SEQLEN_VALS)}]",
+        f"  nhq={NHQ}, nhk={NHK}, hd={HD}, "
+        f"scenarios: kvseqlen=[{','.join(f'{s[0] // 1024}k' for s in SCENARIOS)}], "
+        f"qseqlen=kvseqlen/64, topk=kvseqlen/8",
         flush=True,
     )
 
@@ -550,19 +561,21 @@ def _phase8_bench(force=False, rerun_filter=None):
     print("\n  " + "─" * 55, flush=True)
     print("  8a) kbs=1: IndexSparse vs Baselines (FWD + BWD LoopK)", flush=True)
     print("  " + "─" * 55, flush=True)
-    for pass_type in KBS1_PASSES:
-        for method in KBS1_METHODS:
-            for S in SEQLEN_VALS:
+    for kvseqlen, qseqlen, topk in SCENARIOS:
+        print(
+            f"  ── kvseqlen={kvseqlen // 1024}k, "
+            f"qseqlen={qseqlen}, topk={topk // 1024}k ──",
+            flush=True,
+        )
+        for pass_type in KBS1_PASSES:
+            for method in KBS1_METHODS:
                 key = f"kbs1/{pass_type}/{method}"
-                if rerun_filter and (pass_type, method, S) not in rerun_filter:
-                    continue
-                if not force and _has_entry(results, key, S):
+                if not force and _has_entry(results, key, kvseqlen):
                     d = results[key]
-                    idx = d["seqlen"].index(S)
+                    idx = d["kvseqlen"].index(kvseqlen)
                     tf = d["tflops"][idx]
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
-                        f"{tf:>7.1f} T (cached)",
+                        f"    {pass_type:10s} {method:10s}: " f"{tf:>7.1f} T (cached)",
                         flush=True,
                     )
                     continue
@@ -571,29 +584,28 @@ def _phase8_bench(force=False, rerun_filter=None):
                 torch.cuda.empty_cache()
                 try:
                     runner = _KBS1_RUNNERS[method]
-                    tf, ms = runner(S, TOPK, pass_type, device)
-                    _set_entry(results, key, S, round(tf, 1), round(ms, 3))
+                    tf, ms = runner(kvseqlen, qseqlen, topk, pass_type, device)
+                    _set_entry(results, key, kvseqlen, round(tf, 1), round(ms, 3))
                     _save_results(PHASE, results)
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s}: "
                         f"{tf:>7.1f} T  ({ms:.3f} ms)",
                         flush=True,
                     )
                 except torch.cuda.OutOfMemoryError:
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: OOM",
+                        f"    {pass_type:10s} {method:10s}: OOM",
                         flush=True,
                     )
-                    _set_entry(results, key, S, None, None)
+                    _set_entry(results, key, kvseqlen, None, None)
                     _save_results(PHASE, results)
                     torch.cuda.empty_cache()
                 except Exception as e:
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
-                        f"ERR — {e}",
+                        f"    {pass_type:10s} {method:10s}: ERR — {e}",
                         flush=True,
                     )
-                    _set_entry(results, key, S, None, None)
+                    _set_entry(results, key, kvseqlen, None, None)
                     _save_results(PHASE, results)
                     torch.cuda.empty_cache()
 
@@ -604,19 +616,21 @@ def _phase8_bench(force=False, rerun_filter=None):
         flush=True,
     )
     print("  " + "─" * 55, flush=True)
-    for pass_type in KBS128_PASSES:
-        for method in KBS128_METHODS:
-            for S in SEQLEN_VALS:
+    for kvseqlen, qseqlen, topk in SCENARIOS:
+        print(
+            f"  ── kvseqlen={kvseqlen // 1024}k, "
+            f"qseqlen={qseqlen}, topk={topk // 1024}k ──",
+            flush=True,
+        )
+        for pass_type in KBS128_PASSES:
+            for method in KBS128_METHODS:
                 key = f"kbs128/{pass_type}/{method}"
-                if rerun_filter and (pass_type, method, S) not in rerun_filter:
-                    continue
-                if not force and _has_entry(results, key, S):
+                if not force and _has_entry(results, key, kvseqlen):
                     d = results[key]
-                    idx = d["seqlen"].index(S)
+                    idx = d["kvseqlen"].index(kvseqlen)
                     tf = d["tflops"][idx]
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
-                        f"{tf:>7.1f} T (cached)",
+                        f"    {pass_type:10s} {method:10s}: " f"{tf:>7.1f} T (cached)",
                         flush=True,
                     )
                     continue
@@ -625,29 +639,28 @@ def _phase8_bench(force=False, rerun_filter=None):
                 torch.cuda.empty_cache()
                 try:
                     runner = _KBS128_RUNNERS[method]
-                    tf, ms = runner(S, TOPK, pass_type, device)
-                    _set_entry(results, key, S, round(tf, 1), round(ms, 3))
+                    tf, ms = runner(kvseqlen, qseqlen, topk, pass_type, device)
+                    _set_entry(results, key, kvseqlen, round(tf, 1), round(ms, 3))
                     _save_results(PHASE, results)
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s}: "
                         f"{tf:>7.1f} T  ({ms:.3f} ms)",
                         flush=True,
                     )
                 except torch.cuda.OutOfMemoryError:
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: OOM",
+                        f"    {pass_type:10s} {method:10s}: OOM",
                         flush=True,
                     )
-                    _set_entry(results, key, S, None, None)
+                    _set_entry(results, key, kvseqlen, None, None)
                     _save_results(PHASE, results)
                     torch.cuda.empty_cache()
                 except Exception as e:
                     print(
-                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
-                        f"ERR — {e}",
+                        f"    {pass_type:10s} {method:10s}: ERR — {e}",
                         flush=True,
                     )
-                    _set_entry(results, key, S, None, None)
+                    _set_entry(results, key, kvseqlen, None, None)
                     _save_results(PHASE, results)
                     torch.cuda.empty_cache()
 
@@ -663,7 +676,7 @@ def _phase8_plot():
     """Generate Phase-6 style grouped bar charts: 2 figures (kbs=1, kbs=128).
 
     Each figure has subplots for each pass (FWD, BWD, etc.), with grouped bars
-    per seqlen, one bar per method. TFLOPS on y-axis, seqlen on x-axis.
+    per kvseqlen, one bar per method. TFLOPS on y-axis, kvseqlen on x-axis.
     """
     import matplotlib
 
@@ -679,8 +692,9 @@ def _phase8_plot():
     out = _out_dir(PHASE)
     os.makedirs(out, exist_ok=True)
 
-    x = np.arange(len(SEQLEN_VALS))
-    x_labels = [f"{s // 1024}K" for s in SEQLEN_VALS]
+    kvseqlens = [s[0] for s in SCENARIOS]
+    x = np.arange(len(kvseqlens))
+    x_labels = [f"{kv // 1024}K\n(q={kv // 64}, top={kv // 8192}K)" for kv in kvseqlens]
 
     # ── 8a) kbs=1 ──
     KBS1_PLOT = [
@@ -703,9 +717,9 @@ def _phase8_plot():
             key = f"kbs1/{pid}/{mid}"
             d = results.get(key, {})
             vals = []
-            for S in SEQLEN_VALS:
-                if S in d.get("seqlen", []):
-                    idx = d["seqlen"].index(S)
+            for kv in kvseqlens:
+                if kv in d.get("kvseqlen", []):
+                    idx = d["kvseqlen"].index(kv)
                     v = d["tflops"][idx] if d["tflops"][idx] else 0
                 else:
                     v = 0
@@ -734,17 +748,17 @@ def _phase8_plot():
                     )
 
         ax.set_title(pname, fontsize=13, fontweight="bold")
-        ax.set_xlabel("Sequence Length", fontsize=10)
+        ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
         ax.set_ylabel("TFLOPS", fontsize=12)
         ax.set_xticks(x)
-        ax.set_xticklabels(x_labels, fontsize=10)
+        ax.set_xticklabels(x_labels, fontsize=9)
         ax.tick_params(axis="y", labelsize=11)
         ax.legend(loc="upper right", fontsize=9)
         ax.grid(axis="y", alpha=0.3)
 
     fig.suptitle(
-        f"Phase 8a: Token-Sparse Baseline (kbs=1)\n"
-        f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, bf16, H100",
+        "Phase 8a: Token-Sparse Baseline (kbs=1)\n"
+        f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
         fontsize=13,
         fontweight="bold",
         y=1.02,
@@ -778,9 +792,9 @@ def _phase8_plot():
             key = f"kbs128/{pid}/{mid}"
             d = results.get(key, {})
             vals = []
-            for S in SEQLEN_VALS:
-                if S in d.get("seqlen", []):
-                    idx = d["seqlen"].index(S)
+            for kv in kvseqlens:
+                if kv in d.get("kvseqlen", []):
+                    idx = d["kvseqlen"].index(kv)
                     v = d["tflops"][idx] if d["tflops"][idx] else 0
                 else:
                     v = 0
@@ -809,17 +823,17 @@ def _phase8_plot():
                     )
 
         ax.set_title(pname, fontsize=13, fontweight="bold")
-        ax.set_xlabel("Sequence Length", fontsize=10)
+        ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
         ax.set_ylabel("TFLOPS", fontsize=12)
         ax.set_xticks(x)
-        ax.set_xticklabels(x_labels, fontsize=10)
+        ax.set_xticklabels(x_labels, fontsize=9)
         ax.tick_params(axis="y", labelsize=11)
         ax.legend(loc="upper right", fontsize=9)
         ax.grid(axis="y", alpha=0.3)
 
     fig.suptitle(
         f"Phase 8b: Block-Sparse Baseline (kbs={KBS_BLOCK})\n"
-        f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, bf16, H100",
+        f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
         fontsize=13,
         fontweight="bold",
         y=1.02,
@@ -841,17 +855,17 @@ def _phase8_plot():
     ]:
         for pt in passes:
             print(f"\n  {pt.upper()} ({prefix}):")
-            header = f"  {'S':>6s}"
+            header = f"  {'kvseqlen':>8s}"
             for m in methods:
                 header += f"  {labels[m]:>24s}"
             print(header)
-            for S in SEQLEN_VALS:
-                row = f"  {S // 1024:>5d}k"
+            for kv in kvseqlens:
+                row = f"  {kv // 1024:>7d}k"
                 for m in methods:
                     key = f"{prefix}/{pt}/{m}"
                     d = results.get(key, {})
-                    if d and S in d.get("seqlen", []):
-                        idx = d["seqlen"].index(S)
+                    if d and kv in d.get("kvseqlen", []):
+                        idx = d["kvseqlen"].index(kv)
                         tf = d["tflops"][idx]
                         row += f"  {tf:>24.1f}" if tf else f"  {'—':>24s}"
                     else:

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -425,7 +425,7 @@ def _sanity_check(device):
     from magi_attention.functional import flex_flash_attn_func
     from magi_attention.utils.sparse_utils import generate_ranges_from_topk_indices
 
-    kvseqlen_ck, qseqlen_ck, topk_ck = 512, 64, 128
+    kvseqlen_ck, qseqlen_ck, topk_ck = 2048, 256, 256
     torch.manual_seed(42)
     q = torch.randn(qseqlen_ck, NHQ, HD, dtype=torch.bfloat16, device=device)
     k = torch.randn(kvseqlen_ck, NHK, HD, dtype=torch.bfloat16, device=device)
@@ -521,7 +521,7 @@ def _sanity_check(device):
     results["triton"] = (tri_out[:64].float() - ref.float()).abs().max().item()
 
     # Print
-    print("  Correctness check (kvseqlen=512, qseqlen=64, topk=128):", flush=True)
+    print("  Correctness check (kvseqlen=2048, qseqlen=256, topk=256):", flush=True)
     all_pass = True
     for method, val in results.items():
         status = "PASS" if val < 0.05 else f"FAIL (err={val:.4f})"

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -660,7 +660,16 @@ def _phase8_bench(force=False, rerun_filter=None):
 
 
 def _phase8_plot():
+    """Generate Phase-6 style grouped bar charts: 2 figures (kbs=1, kbs=128).
+
+    Each figure has subplots for each pass (FWD, BWD, etc.), with grouped bars
+    per seqlen, one bar per method. TFLOPS on y-axis, seqlen on x-axis.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
+    import numpy as np
 
     results = _load_results(PHASE)
     if not results:
@@ -670,75 +679,156 @@ def _phase8_plot():
     out = _out_dir(PHASE)
     os.makedirs(out, exist_ok=True)
 
-    COLORS = {
-        "ffa_is": "red",
-        "ffa_bs": "red",
-        "ffa_is128": "orange",
-        "flexattn": "green",
-        "triton": "blue",
-    }
-    MARKERS = {
-        "ffa_is": "o",
-        "ffa_bs": "s",
-        "ffa_is128": "D",
-        "flexattn": "^",
-        "triton": "v",
-    }
+    x = np.arange(len(SEQLEN_VALS))
+    x_labels = [f"{s // 1024}K" for s in SEQLEN_VALS]
 
-    def _plot_group(prefix, methods, labels, pass_type, title_extra, fname):
-        fig, ax = plt.subplots(figsize=(10, 6))
-        has_data = False
-        for m in methods:
-            key = f"{prefix}/{pass_type}/{m}"
-            d = results.get(key)
-            if not d:
-                continue
-            valid = [(s, t) for s, t in zip(d["seqlen"], d["tflops"]) if t is not None]
-            if not valid:
-                continue
-            xs, ys = zip(*valid)
-            ax.plot(
-                [x // 1024 for x in xs],
-                ys,
-                marker=MARKERS.get(m, "o"),
-                color=COLORS.get(m, "gray"),
-                label=labels[m],
-                linewidth=2,
-                markersize=7,
+    # ── 8a) kbs=1 ──
+    KBS1_PLOT = [
+        ("ffa_is", "FFA IndexSparse", (0.85, 0.25, 0.25)),
+        ("flexattn", "FlexAttention", (0.30, 0.70, 0.35)),
+        ("triton", "Triton Token-Sparse", (0.25, 0.45, 0.80)),
+    ]
+    KBS1_PASS_LABELS = [("fwd", "FWD"), ("bwd", "BWD (LoopK)")]
+
+    n_cols = len(KBS1_PASS_LABELS)
+    fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
+    if n_cols == 1:
+        axes = [axes]
+
+    for col_idx, (pid, pname) in enumerate(KBS1_PASS_LABELS):
+        ax = axes[col_idx]
+        n_m = len(KBS1_PLOT)
+        bw = 0.8 / n_m
+        for i, (mid, lbl, col) in enumerate(KBS1_PLOT):
+            key = f"kbs1/{pid}/{mid}"
+            d = results.get(key, {})
+            vals = []
+            for S in SEQLEN_VALS:
+                if S in d.get("seqlen", []):
+                    idx = d["seqlen"].index(S)
+                    v = d["tflops"][idx] if d["tflops"][idx] else 0
+                else:
+                    v = 0
+                vals.append(v)
+            off = (i - n_m / 2 + 0.5) * bw
+            bars = ax.bar(
+                x + off,
+                vals,
+                width=bw,
+                label=lbl,
+                color=col,
+                edgecolor="white",
+                linewidth=0.5,
+                alpha=0.85,
             )
-            has_data = True
-        if not has_data:
-            plt.close(fig)
-            return
-        ax.set_title(
-            f"Sparse Attention {pass_type.upper()} — {title_extra}\n"
-            f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}"
-        )
-        ax.set_xlabel("Sequence Length (K)")
-        ax.set_ylabel("Effective Sparse TFLOPS/s")
-        ax.legend()
-        ax.grid(True, alpha=0.3)
-        ax.set_xscale("log", base=2)
-        ax.set_xticks([s // 1024 for s in SEQLEN_VALS])
-        ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda x, _: f"{int(x)}K"))
-        fig.savefig(os.path.join(out, fname), dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        print(f"  Saved: {fname}", flush=True)
+            for bar, v in zip(bars, vals):
+                if v > 0:
+                    ax.text(
+                        bar.get_x() + bar.get_width() / 2,
+                        bar.get_height() + 5,
+                        f"{v:.0f}",
+                        ha="center",
+                        va="bottom",
+                        fontsize=7,
+                        fontweight="bold",
+                    )
 
-    # 8a plots
-    for pt in KBS1_PASSES:
-        _plot_group("kbs1", KBS1_METHODS, KBS1_LABELS, pt, "kbs=1", f"kbs1_{pt}.png")
+        ax.set_title(pname, fontsize=13, fontweight="bold")
+        ax.set_xlabel("Sequence Length", fontsize=10)
+        ax.set_ylabel("TFLOPS", fontsize=12)
+        ax.set_xticks(x)
+        ax.set_xticklabels(x_labels, fontsize=10)
+        ax.tick_params(axis="y", labelsize=11)
+        ax.legend(loc="upper right", fontsize=9)
+        ax.grid(axis="y", alpha=0.3)
 
-    # 8b plots
-    for pt in KBS128_PASSES:
-        _plot_group(
-            "kbs128",
-            KBS128_METHODS,
-            KBS128_LABELS,
-            pt,
-            f"kbs={KBS_BLOCK}",
-            f"kbs128_{pt}.png",
-        )
+    fig.suptitle(
+        f"Phase 8a: Token-Sparse Baseline (kbs=1)\n"
+        f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, bf16, H100",
+        fontsize=13,
+        fontweight="bold",
+        y=1.02,
+    )
+    plt.tight_layout()
+    path = os.path.join(out, "phase8a_kbs1.png")
+    fig.savefig(path, dpi=180, bbox_inches="tight")
+    plt.close()
+    print(f"  Saved: {path}", flush=True)
+
+    # ── 8b) kbs=128 ──
+    KBS128_PLOT = [
+        ("ffa_bs", "FFA BlockSparse", (0.29, 0.57, 0.60)),
+        ("ffa_is128", "FFA IndexSparse (kbs=128)", (0.85, 0.45, 0.20)),
+        ("flexattn", "FlexAttention", (0.30, 0.70, 0.35)),
+    ]
+    KBS128_PASS_LABELS = [
+        ("fwd", "FWD"),
+        ("bwd_loopk", "BWD LoopK"),
+        ("bwd_loopq", "BWD LoopQ"),
+    ]
+
+    n_cols = len(KBS128_PASS_LABELS)
+    fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
+
+    for col_idx, (pid, pname) in enumerate(KBS128_PASS_LABELS):
+        ax = axes[col_idx]
+        n_m = len(KBS128_PLOT)
+        bw = 0.8 / n_m
+        for i, (mid, lbl, col) in enumerate(KBS128_PLOT):
+            key = f"kbs128/{pid}/{mid}"
+            d = results.get(key, {})
+            vals = []
+            for S in SEQLEN_VALS:
+                if S in d.get("seqlen", []):
+                    idx = d["seqlen"].index(S)
+                    v = d["tflops"][idx] if d["tflops"][idx] else 0
+                else:
+                    v = 0
+                vals.append(v)
+            off = (i - n_m / 2 + 0.5) * bw
+            bars = ax.bar(
+                x + off,
+                vals,
+                width=bw,
+                label=lbl,
+                color=col,
+                edgecolor="white",
+                linewidth=0.5,
+                alpha=0.85,
+            )
+            for bar, v in zip(bars, vals):
+                if v > 0:
+                    ax.text(
+                        bar.get_x() + bar.get_width() / 2,
+                        bar.get_height() + 5,
+                        f"{v:.0f}",
+                        ha="center",
+                        va="bottom",
+                        fontsize=7,
+                        fontweight="bold",
+                    )
+
+        ax.set_title(pname, fontsize=13, fontweight="bold")
+        ax.set_xlabel("Sequence Length", fontsize=10)
+        ax.set_ylabel("TFLOPS", fontsize=12)
+        ax.set_xticks(x)
+        ax.set_xticklabels(x_labels, fontsize=10)
+        ax.tick_params(axis="y", labelsize=11)
+        ax.legend(loc="upper right", fontsize=9)
+        ax.grid(axis="y", alpha=0.3)
+
+    fig.suptitle(
+        f"Phase 8b: Block-Sparse Baseline (kbs={KBS_BLOCK})\n"
+        f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}, bf16, H100",
+        fontsize=13,
+        fontweight="bold",
+        y=1.02,
+    )
+    plt.tight_layout()
+    path = os.path.join(out, "phase8b_kbs128.png")
+    fig.savefig(path, dpi=180, bbox_inches="tight")
+    plt.close()
+    print(f"  Saved: {path}", flush=True)
 
     # Summary tables
     print("\n  " + "─" * 60)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -14,16 +14,17 @@
 
 """Phase 8: Baseline Comparison — FFA IndexSparse/BlockSparse vs external kernels.
 
-Compare MagiAttention sparse kernels against publicly available baselines:
-  - FlexAttention: PyTorch flex_attention + block_mask (Triton compiled)
-  - Triton Token-Sparse: Hand-written Triton MQA-optimized (tl.dot)
+Two sub-benchmarks organized by K block size:
 
-Two sub-benchmarks:
-  8a) IndexSparse (kbs=1): token-level sparsity
-  8b) BlockSparse (kbs=128): block-level sparsity (FlexAttention only)
+  8a) kbs=1 (token-sparse):
+      FFA IndexSparse vs FlexAttention vs Triton Token-Sparse
+      Passes: FWD, BWD (LoopK only — IS kbs=1 has no LoopQ)
+
+  8b) kbs=128 (block-sparse):
+      FFA BlockSparse vs FFA IndexSparse(kbs=128) vs FlexAttention
+      Passes: FWD, BWD_LoopK, BWD_LoopQ
 
 Config: nhq=128, nhk=1, hd=128, topk=2048 (fixed), sweep S=[32K..512K].
-Passes: FWD, BWD.
 """
 
 import gc
@@ -50,21 +51,23 @@ PHASE = "8-baseline-comparison"
 TOPK = 2048
 KBS_BLOCK = 128
 SEQLEN_VALS = [32768, 65536, 131072, 262144, 524288]
-PASSES = ["fwd", "bwd"]
 
-# Index Sparse methods (kbs=1)
-IS_METHODS = ["ffa_index_sparse", "flexattention", "triton_token_sparse"]
-IS_METHOD_LABELS = {
-    "ffa_index_sparse": "FFA IndexSparse",
-    "flexattention": "FlexAttention",
-    "triton_token_sparse": "Triton Token-Sparse",
+# 8a: kbs=1 (token-sparse)
+KBS1_METHODS = ["ffa_is", "flexattn", "triton"]
+KBS1_PASSES = ["fwd", "bwd"]
+KBS1_LABELS = {
+    "ffa_is": "FFA IndexSparse (kbs=1)",
+    "flexattn": "FlexAttention",
+    "triton": "Triton Token-Sparse",
 }
 
-# Block Sparse methods (kbs=128)
-BS_METHODS = ["ffa_block_sparse", "flexattention"]
-BS_METHOD_LABELS = {
-    "ffa_block_sparse": "FFA BlockSparse",
-    "flexattention": "FlexAttention",
+# 8b: kbs=128 (block-sparse)
+KBS128_METHODS = ["ffa_bs", "ffa_is128", "flexattn"]
+KBS128_PASSES = ["fwd", "bwd_loopk", "bwd_loopq"]
+KBS128_LABELS = {
+    "ffa_bs": "FFA BlockSparse",
+    "ffa_is128": "FFA IndexSparse (kbs=128)",
+    "flexattn": "FlexAttention",
 }
 
 
@@ -76,15 +79,6 @@ BS_METHOD_LABELS = {
 def _calc_sparse_flops(S, topk, is_bwd):
     fwd = 4 * S * topk * NHQ * HD
     return fwd * 2.5 if is_bwd else fwd
-
-
-def _build_index_sparse_indices(S, topk, device):
-    """(S, NHK, topk) int32 — random per-Q-position token indices."""
-    import torch
-
-    idx = torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
-    idx = idx.sort(dim=1).values
-    return idx.unsqueeze(1).expand(-1, NHK, -1).contiguous()
 
 
 def _build_flex_block_mask(S, topk, device):
@@ -115,24 +109,6 @@ def _build_flex_block_mask(S, topk, device):
     )
 
 
-def _build_block_sparse_indices(S, topk, device):
-    """(S, NHK, n_topk_blocks) int32 — block-level indices for FFA BlockSparse."""
-    import torch
-
-    n_kv_blocks = S // KBS_BLOCK
-    n_topk_blocks = topk // KBS_BLOCK
-    if n_topk_blocks >= n_kv_blocks:
-        idx = torch.arange(n_kv_blocks, dtype=torch.int32, device=device)
-        return idx.unsqueeze(0).unsqueeze(0).expand(S, NHK, -1).contiguous()
-    idx = (
-        torch.rand(S, n_kv_blocks, device=device)
-        .argsort(dim=1)[:, :n_topk_blocks]
-        .sort(dim=1)
-        .values
-    )
-    return idx.unsqueeze(1).expand(-1, NHK, -1).to(torch.int32).contiguous()
-
-
 def _has_entry(results, key, S):
     d = results.get(key, {})
     if not d or "seqlen" not in d:
@@ -159,11 +135,12 @@ def _set_entry(results, key, S, tflops, ms):
 
 
 # ═══════════════════════════════════════════════════════════════
-#  Index Sparse Runners
+#  8a: kbs=1 Runners
 # ═══════════════════════════════════════════════════════════════
 
 
-def _run_ffa_index_sparse(S, topk, is_bwd, device):
+def _run_kbs1_ffa_is(S, topk, pass_type, device):
+    """FFA IndexSparse kbs=1. BWD always uses LoopK (no LoopQ for kbs=1)."""
     import torch
 
     from magi_attention.functional import flex_flash_attn_func
@@ -171,8 +148,14 @@ def _run_ffa_index_sparse(S, topk, is_bwd, device):
     q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
     k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
     v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
-    indices = _build_index_sparse_indices(S, topk, device)
-
+    indices = (
+        torch.randint(0, S, (S, topk), device=device, dtype=torch.int32)
+        .sort(dim=1)
+        .values.unsqueeze(1)
+        .expand(-1, NHK, -1)
+        .contiguous()
+    )
+    is_bwd = pass_type != "fwd"
     kw = dict(
         index_sparse_indices=indices,
         q_block_size=1,
@@ -180,7 +163,6 @@ def _run_ffa_index_sparse(S, topk, is_bwd, device):
         pack_gqa=True,
         disable_fwd_atomic_reduction=True,
     )
-
     if is_bwd:
         q.requires_grad_(True)
         k.requires_grad_(True)
@@ -196,11 +178,11 @@ def _run_ffa_index_sparse(S, topk, is_bwd, device):
         def run_fn():
             flex_flash_attn_func(q, k, v, **kw)
 
-    flops = _calc_sparse_flops(S, topk, is_bwd)
-    return _bench_kernel(run_fn, flops, device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
 
 
-def _run_flexattention(S, topk, is_bwd, device):
+def _run_kbs1_flexattn(S, topk, pass_type, device):
+    """FlexAttention with sparse block mask."""
     import torch
     from torch.nn.attention.flex_attention import flex_attention
 
@@ -209,6 +191,7 @@ def _run_flexattention(S, topk, is_bwd, device):
     v = torch.randn(1, NHK, S, HD, dtype=torch.bfloat16, device=device)
     block_mask = _build_flex_block_mask(S, topk, device)
     _flex_fn = torch.compile(flex_attention)
+    is_bwd = pass_type != "fwd"
 
     if is_bwd:
         q.requires_grad_(True)
@@ -225,11 +208,11 @@ def _run_flexattention(S, topk, is_bwd, device):
         def run_fn():
             _flex_fn(q, k, v, block_mask=block_mask, enable_gqa=True)
 
-    flops = _calc_sparse_flops(S, topk, is_bwd)
-    return _bench_kernel(run_fn, flops, device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
 
 
-def _run_triton_token_sparse(S, topk, is_bwd, device):
+def _run_kbs1_triton(S, topk, pass_type, device):
+    """Triton hand-written token-sparse kernel."""
     import torch
 
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
@@ -243,6 +226,7 @@ def _run_triton_token_sparse(S, topk, is_bwd, device):
         .sort(dim=1)
         .values
     )
+    is_bwd = pass_type != "fwd"
 
     if is_bwd:
         q.requires_grad_(True)
@@ -259,16 +243,16 @@ def _run_triton_token_sparse(S, topk, is_bwd, device):
         def run_fn():
             token_sparse_fwd(q, k, v, tri_indices)
 
-    flops = _calc_sparse_flops(S, topk, is_bwd)
-    return _bench_kernel(run_fn, flops, device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
 
 
 # ═══════════════════════════════════════════════════════════════
-#  Block Sparse Runners
+#  8b: kbs=128 Runners
 # ═══════════════════════════════════════════════════════════════
 
 
-def _run_ffa_block_sparse(S, topk, is_bwd, device):
+def _run_kbs128_ffa_bs(S, topk, pass_type, device):
+    """FFA BlockSparse (q_ranges/k_ranges + block_sparse + range_merge)."""
     import torch
 
     from magi_attention.functional import flex_flash_attn_func
@@ -277,14 +261,26 @@ def _run_ffa_block_sparse(S, topk, is_bwd, device):
     q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
     k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
     v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
-    indices = _build_block_sparse_indices(S, topk, device)
 
+    n_kv_blocks = S // KBS_BLOCK
+    n_topk_blocks = topk // KBS_BLOCK
+    indices = (
+        torch.rand(S, n_kv_blocks, device=device)
+        .argsort(dim=1)[:, :n_topk_blocks]
+        .sort(dim=1)
+        .values.unsqueeze(1)
+        .expand(-1, NHK, -1)
+        .to(torch.int32)
+        .contiguous()
+    )
     ia_3d = indices.permute(1, 0, 2).contiguous()
     q_ranges, k_ranges = generate_ranges_from_topk_indices(
-        ia_3d, block_m=1, block_n=KBS_BLOCK, num_k_blocks=S // KBS_BLOCK
+        ia_3d, block_m=1, block_n=KBS_BLOCK, num_k_blocks=n_kv_blocks
     )
     atm = torch.zeros(q_ranges.size(0), dtype=torch.int32, device=device)
 
+    is_bwd = pass_type != "fwd"
+    swap_qk = pass_type == "bwd_loopk"
     kw = dict(
         q_ranges=q_ranges,
         k_ranges=k_ranges,
@@ -294,8 +290,8 @@ def _run_ffa_block_sparse(S, topk, is_bwd, device):
         range_merge=True,
         disable_fwd_atomic_reduction=True,
     )
-
     if is_bwd:
+        kw["swap_bwd_qk_loop"] = swap_qk
         q.requires_grad_(True)
         k.requires_grad_(True)
         v.requires_grad_(True)
@@ -310,19 +306,78 @@ def _run_ffa_block_sparse(S, topk, is_bwd, device):
         def run_fn():
             flex_flash_attn_func(q, k, v, **kw)
 
-    flops = _calc_sparse_flops(S, topk, is_bwd)
-    return _bench_kernel(run_fn, flops, device)
+    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+
+
+def _run_kbs128_ffa_is(S, topk, pass_type, device):
+    """FFA IndexSparse with kbs=128 (index_sparse_indices with block indices)."""
+    import torch
+
+    from magi_attention.functional import flex_flash_attn_func
+
+    q = torch.randn(S, NHQ, HD, dtype=torch.bfloat16, device=device)
+    k = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+    v = torch.randn(S, NHK, HD, dtype=torch.bfloat16, device=device)
+
+    n_kv_blocks = S // KBS_BLOCK
+    n_topk_blocks = topk // KBS_BLOCK
+    indices = (
+        torch.rand(S, n_kv_blocks, device=device)
+        .argsort(dim=1)[:, :n_topk_blocks]
+        .sort(dim=1)
+        .values.unsqueeze(1)
+        .expand(-1, NHK, -1)
+        .to(torch.int32)
+        .contiguous()
+    )
+
+    is_bwd = pass_type != "fwd"
+    swap_qk = pass_type == "bwd_loopk"
+    kw = dict(
+        index_sparse_indices=indices,
+        q_block_size=1,
+        sparse_k_block_size=KBS_BLOCK,
+        pack_gqa=True,
+        disable_fwd_atomic_reduction=True,
+    )
+    if is_bwd:
+        kw["swap_bwd_qk_loop"] = swap_qk
+        q.requires_grad_(True)
+        k.requires_grad_(True)
+        v.requires_grad_(True)
+        o, *_ = flex_flash_attn_func(q, k, v, **kw)
+        do = torch.randn_like(o)
+
+        def run_fn():
+            o.backward(do, retain_graph=True)
+
+    else:
+
+        def run_fn():
+            flex_flash_attn_func(q, k, v, **kw)
+
+    return _bench_kernel(run_fn, _calc_sparse_flops(S, topk, is_bwd), device)
+
+
+def _run_kbs128_flexattn(S, topk, pass_type, device):
+    """FlexAttention (same for kbs=128 group — block mask matches 128-block granularity)."""
+    return _run_kbs1_flexattn(S, topk, pass_type, device)
 
 
 # ═══════════════════════════════════════════════════════════════
 #  Dispatch
 # ═══════════════════════════════════════════════════════════════
 
-_RUNNERS = {
-    "ffa_index_sparse": _run_ffa_index_sparse,
-    "ffa_block_sparse": _run_ffa_block_sparse,
-    "flexattention": _run_flexattention,
-    "triton_token_sparse": _run_triton_token_sparse,
+_KBS1_RUNNERS = {
+    "ffa_is": _run_kbs1_ffa_is,
+    "flexattn": _run_kbs1_flexattn,
+    "triton": _run_kbs1_triton,
+}
+
+_KBS128_RUNNERS = {
+    "ffa_bs": _run_kbs128_ffa_bs,
+    "ffa_is128": _run_kbs128_ffa_is,
+    "flexattn": _run_kbs128_flexattn,
 }
 
 
@@ -332,16 +387,16 @@ _RUNNERS = {
 
 
 def _ref_token_sparse_attn(q, k, v, indices, sm_scale=None):
-    """Naive reference: per-query gather topk KV → softmax → output."""
+    """Naive reference: per-query gather topk KV → softmax → output (first 64 rows)."""
     import torch
 
-    S, Hq, D = q.shape
+    S, _Hq, D = q.shape
     if sm_scale is None:
         sm_scale = 1.0 / (D**0.5)
     q_f = q.float()
     k_f = k.squeeze(1).float()
     v_f = v.squeeze(1).float()
-    o = torch.zeros_like(q_f)
+    o = torch.zeros(min(S, 64), _Hq, D, dtype=torch.float32, device=q.device)
     for i in range(min(S, 64)):
         idx = indices[i].long()
         ki = k_f[idx]
@@ -350,7 +405,7 @@ def _ref_token_sparse_attn(q, k, v, indices, sm_scale=None):
         scores = (qi @ ki.T) * sm_scale
         weights = torch.softmax(scores, dim=-1)
         o[i] = weights @ vi
-    return o[:64].to(q.dtype)
+    return o.to(q.dtype)
 
 
 def _sanity_check(device):
@@ -366,18 +421,15 @@ def _sanity_check(device):
     k = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
     v = torch.randn(S_ck, NHK, HD, dtype=torch.bfloat16, device=device)
 
-    # Shared indices for fair comparison
     indices_2d = (
         torch.randint(0, S_ck, (S_ck, topk_ck), device=device, dtype=torch.int32)
         .sort(dim=1)
         .values
     )
-    # Reference (first 64 rows only for speed)
     ref = _ref_token_sparse_attn(q, k, v, indices_2d)
-
     results = {}
 
-    # 1. FFA IndexSparse
+    # 1. FFA IndexSparse kbs=1
     is_indices = indices_2d.unsqueeze(1).expand(-1, NHK, -1).contiguous()
     ffa_out, *_ = flex_flash_attn_func(
         q,
@@ -389,10 +441,9 @@ def _sanity_check(device):
         pack_gqa=True,
         disable_fwd_atomic_reduction=True,
     )
-    err = (ffa_out[:64].float() - ref.float()).abs().max().item()
-    results["ffa_index_sparse"] = err
+    results["ffa_is_kbs1"] = (ffa_out[:64].float() - ref.float()).abs().max().item()
 
-    # 2. FFA BlockSparse (kbs=128)
+    # 2. FFA BlockSparse kbs=128
     n_kv_blocks = S_ck // KBS_BLOCK
     n_topk_blocks = topk_ck // KBS_BLOCK
     bs_idx = (
@@ -421,54 +472,52 @@ def _sanity_check(device):
         range_merge=True,
         disable_fwd_atomic_reduction=True,
     )
-    # BS attends to DIFFERENT K positions (blocks of 128) so can't compare to ref directly.
-    # Just check it doesn't produce NaN/Inf and output shape is correct.
-    bs_ok = (
-        not torch.isnan(bs_out).any().item()
-        and not torch.isinf(bs_out).any().item()
-        and bs_out.shape == (S_ck, NHQ, HD)
-    )
-    results["ffa_block_sparse"] = 0.0 if bs_ok else float("inf")
+    bs_ok = not torch.isnan(bs_out).any() and not torch.isinf(bs_out).any()
+    results["ffa_bs_kbs128"] = 0.0 if bs_ok else float("inf")
 
-    # 3. FlexAttention
+    # 3. FFA IndexSparse kbs=128
+    is128_out, *_ = flex_flash_attn_func(
+        q,
+        k,
+        v,
+        index_sparse_indices=bs_idx,
+        q_block_size=1,
+        sparse_k_block_size=KBS_BLOCK,
+        pack_gqa=True,
+        disable_fwd_atomic_reduction=True,
+    )
+    is128_ok = not torch.isnan(is128_out).any() and not torch.isinf(is128_out).any()
+    results["ffa_is_kbs128"] = 0.0 if is128_ok else float("inf")
+
+    # 4. FlexAttention
     from torch.nn.attention.flex_attention import flex_attention
 
-    q_bhsd = q.unsqueeze(0).permute(0, 2, 1, 3)  # (1, NHQ, S, HD)
+    q_bhsd = q.unsqueeze(0).permute(0, 2, 1, 3)
     k_bhsd = k.unsqueeze(0).permute(0, 2, 1, 3)
     v_bhsd = v.unsqueeze(0).permute(0, 2, 1, 3)
     block_mask = _build_flex_block_mask(S_ck, topk_ck, device)
     flex_fn = torch.compile(flex_attention)
     flex_out = flex_fn(q_bhsd, k_bhsd, v_bhsd, block_mask=block_mask, enable_gqa=True)
-    flex_ok = (
-        not torch.isnan(flex_out).any().item()
-        and not torch.isinf(flex_out).any().item()
-        and flex_out.shape == (1, NHQ, S_ck, HD)
-    )
-    results["flexattention"] = 0.0 if flex_ok else float("inf")
+    flex_ok = not torch.isnan(flex_out).any() and not torch.isinf(flex_out).any()
+    results["flexattn"] = 0.0 if flex_ok else float("inf")
 
-    # 4. Triton Token-Sparse
+    # 5. Triton Token-Sparse
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "baselines"))
     from token_sparse_attn_triton import token_sparse_fwd
 
     tri_out = token_sparse_fwd(q, k, v, indices_2d)
-    err_tri = (tri_out[:64].float() - ref.float()).abs().max().item()
-    results["triton_token_sparse"] = err_tri
+    results["triton"] = (tri_out[:64].float() - ref.float()).abs().max().item()
 
-    # Print results
-    print("  Correctness verification (S=512, topk=128):", flush=True)
+    # Print
+    print("  Correctness check (S=512, topk=128):", flush=True)
     all_pass = True
     for method, val in results.items():
-        if val < 0.05:
-            status = "PASS"
-        elif val == 0.0:
-            status = "PASS (shape/nan check)"
-        else:
-            status = f"FAIL (max_err={val:.4f})"
+        status = "PASS" if val < 0.05 else f"FAIL (err={val:.4f})"
+        if val >= 0.05:
             all_pass = False
-        print(f"    {method:22s}: {status}", flush=True)
-
+        print(f"    {method:18s}: {status}", flush=True)
     if not all_pass:
-        print("  [ERROR] Correctness check failed! Aborting.", flush=True)
+        print("  [ERROR] Correctness failed! Aborting.", flush=True)
     return all_pass
 
 
@@ -490,21 +539,19 @@ def _phase8_bench(force=False, rerun_filter=None):
         f"S=[{','.join(f'{s // 1024}k' for s in SEQLEN_VALS)}]",
         flush=True,
     )
-    print(f"  Passes: {PASSES}\n", flush=True)
 
     # Correctness verification first
     if not _sanity_check(device):
         return
 
-    # --- 8a: IndexSparse ---
-    print("  " + "─" * 50, flush=True)
-    print("  8a) IndexSparse (kbs=1) vs Baselines", flush=True)
-    print("  " + "─" * 50, flush=True)
-    for pass_type in PASSES:
-        is_bwd = pass_type == "bwd"
-        for method in IS_METHODS:
+    # --- 8a: kbs=1 ---
+    print("\n  " + "─" * 55, flush=True)
+    print("  8a) kbs=1: IndexSparse vs Baselines (FWD + BWD LoopK)", flush=True)
+    print("  " + "─" * 55, flush=True)
+    for pass_type in KBS1_PASSES:
+        for method in KBS1_METHODS:
             for S in SEQLEN_VALS:
-                key = f"is/{pass_type}/{method}"
+                key = f"kbs1/{pass_type}/{method}"
                 if rerun_filter and (pass_type, method, S) not in rerun_filter:
                     continue
                 if not force and _has_entry(results, key, S):
@@ -512,7 +559,7 @@ def _phase8_bench(force=False, rerun_filter=None):
                     idx = d["seqlen"].index(S)
                     tf = d["tflops"][idx]
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
                         f"{tf:>7.1f} T (cached)",
                         flush=True,
                     )
@@ -521,18 +568,18 @@ def _phase8_bench(force=False, rerun_filter=None):
                 gc.collect()
                 torch.cuda.empty_cache()
                 try:
-                    runner = _RUNNERS[method]
-                    tf, ms = runner(S, TOPK, is_bwd, device)
+                    runner = _KBS1_RUNNERS[method]
+                    tf, ms = runner(S, TOPK, pass_type, device)
                     _set_entry(results, key, S, round(tf, 1), round(ms, 3))
                     _save_results(PHASE, results)
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
                         f"{tf:>7.1f} T  ({ms:.3f} ms)",
                         flush=True,
                     )
                 except torch.cuda.OutOfMemoryError:
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: OOM",
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: OOM",
                         flush=True,
                     )
                     _set_entry(results, key, S, None, None)
@@ -540,23 +587,25 @@ def _phase8_bench(force=False, rerun_filter=None):
                     torch.cuda.empty_cache()
                 except Exception as e:
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
-                        f"ERROR — {e}",
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
+                        f"ERR — {e}",
                         flush=True,
                     )
                     _set_entry(results, key, S, None, None)
                     _save_results(PHASE, results)
                     torch.cuda.empty_cache()
 
-    # --- 8b: BlockSparse ---
-    print("\n  " + "─" * 50, flush=True)
-    print(f"  8b) BlockSparse (kbs={KBS_BLOCK}) vs Baselines", flush=True)
-    print(f"  {'─' * 50}", flush=True)
-    for pass_type in PASSES:
-        is_bwd = pass_type == "bwd"
-        for method in BS_METHODS:
+    # --- 8b: kbs=128 ---
+    print("\n  " + "─" * 55, flush=True)
+    print(
+        f"  8b) kbs={KBS_BLOCK}: BS/IS vs Baselines " f"(FWD + BWD LoopK + BWD LoopQ)",
+        flush=True,
+    )
+    print("  " + "─" * 55, flush=True)
+    for pass_type in KBS128_PASSES:
+        for method in KBS128_METHODS:
             for S in SEQLEN_VALS:
-                key = f"bs/{pass_type}/{method}"
+                key = f"kbs128/{pass_type}/{method}"
                 if rerun_filter and (pass_type, method, S) not in rerun_filter:
                     continue
                 if not force and _has_entry(results, key, S):
@@ -564,7 +613,7 @@ def _phase8_bench(force=False, rerun_filter=None):
                     idx = d["seqlen"].index(S)
                     tf = d["tflops"][idx]
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
                         f"{tf:>7.1f} T (cached)",
                         flush=True,
                     )
@@ -573,18 +622,18 @@ def _phase8_bench(force=False, rerun_filter=None):
                 gc.collect()
                 torch.cuda.empty_cache()
                 try:
-                    runner = _RUNNERS[method]
-                    tf, ms = runner(S, TOPK, is_bwd, device)
+                    runner = _KBS128_RUNNERS[method]
+                    tf, ms = runner(S, TOPK, pass_type, device)
                     _set_entry(results, key, S, round(tf, 1), round(ms, 3))
                     _save_results(PHASE, results)
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
                         f"{tf:>7.1f} T  ({ms:.3f} ms)",
                         flush=True,
                     )
                 except torch.cuda.OutOfMemoryError:
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: OOM",
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: OOM",
                         flush=True,
                     )
                     _set_entry(results, key, S, None, None)
@@ -592,8 +641,8 @@ def _phase8_bench(force=False, rerun_filter=None):
                     torch.cuda.empty_cache()
                 except Exception as e:
                     print(
-                        f"    {pass_type:4s} {method:22s} S={S // 1024:>4d}k: "
-                        f"ERROR — {e}",
+                        f"    {pass_type:10s} {method:10s} S={S // 1024:>4d}k: "
+                        f"ERR — {e}",
                         flush=True,
                     )
                     _set_entry(results, key, S, None, None)
@@ -619,82 +668,100 @@ def _phase8_plot():
     out = _out_dir(PHASE)
     os.makedirs(out, exist_ok=True)
 
-    for sub, methods, labels in [
-        ("is", IS_METHODS, IS_METHOD_LABELS),
-        ("bs", BS_METHODS, BS_METHOD_LABELS),
-    ]:
-        for pass_type in PASSES:
-            fig, ax = plt.subplots(figsize=(10, 6))
-            has_data = False
-            for method in methods:
-                key = f"{sub}/{pass_type}/{method}"
-                d = results.get(key)
-                if not d:
-                    continue
-                seqlens = d["seqlen"]
-                tflops = d["tflops"]
-                valid = [(s, t) for s, t in zip(seqlens, tflops) if t is not None]
-                if not valid:
-                    continue
-                xs, ys = zip(*valid)
-                ax.plot(
-                    [x // 1024 for x in xs],
-                    ys,
-                    marker="o",
-                    label=labels[method],
-                    linewidth=2,
-                )
-                has_data = True
+    COLORS = {
+        "ffa_is": "red",
+        "ffa_bs": "red",
+        "ffa_is128": "orange",
+        "flexattn": "green",
+        "triton": "blue",
+    }
+    MARKERS = {
+        "ffa_is": "o",
+        "ffa_bs": "s",
+        "ffa_is128": "D",
+        "flexattn": "^",
+        "triton": "v",
+    }
 
-            if not has_data:
-                plt.close(fig)
+    def _plot_group(prefix, methods, labels, pass_type, title_extra, fname):
+        fig, ax = plt.subplots(figsize=(10, 6))
+        has_data = False
+        for m in methods:
+            key = f"{prefix}/{pass_type}/{m}"
+            d = results.get(key)
+            if not d:
                 continue
-
-            kbs_label = "kbs=1" if sub == "is" else f"kbs={KBS_BLOCK}"
-            title = (
-                f"Sparse Attention {pass_type.upper()} — {kbs_label}\n"
-                f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}"
+            valid = [(s, t) for s, t in zip(d["seqlen"], d["tflops"]) if t is not None]
+            if not valid:
+                continue
+            xs, ys = zip(*valid)
+            ax.plot(
+                [x // 1024 for x in xs],
+                ys,
+                marker=MARKERS.get(m, "o"),
+                color=COLORS.get(m, "gray"),
+                label=labels[m],
+                linewidth=2,
+                markersize=7,
             )
-            ax.set_title(title)
-            ax.set_xlabel("Sequence Length (K)")
-            ax.set_ylabel("Effective Sparse TFLOPS/s")
-            ax.legend()
-            ax.grid(True, alpha=0.3)
-            ax.set_xscale("log", base=2)
-            ax.set_xticks([s // 1024 for s in SEQLEN_VALS])
-            ax.get_xaxis().set_major_formatter(
-                plt.FuncFormatter(lambda x, _: f"{int(x)}K")
-            )
-
-            fname = f"{sub}_{pass_type}.png"
-            fig.savefig(os.path.join(out, fname), dpi=150, bbox_inches="tight")
+            has_data = True
+        if not has_data:
             plt.close(fig)
-            print(f"  Saved: {os.path.join(out, fname)}", flush=True)
+            return
+        ax.set_title(
+            f"Sparse Attention {pass_type.upper()} — {title_extra}\n"
+            f"nhq={NHQ}, nhk={NHK}, hd={HD}, topk={TOPK}"
+        )
+        ax.set_xlabel("Sequence Length (K)")
+        ax.set_ylabel("Effective Sparse TFLOPS/s")
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        ax.set_xscale("log", base=2)
+        ax.set_xticks([s // 1024 for s in SEQLEN_VALS])
+        ax.get_xaxis().set_major_formatter(plt.FuncFormatter(lambda x, _: f"{int(x)}K"))
+        fig.savefig(os.path.join(out, fname), dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved: {fname}", flush=True)
 
-    # Summary table
+    # 8a plots
+    for pt in KBS1_PASSES:
+        _plot_group("kbs1", KBS1_METHODS, KBS1_LABELS, pt, "kbs=1", f"kbs1_{pt}.png")
+
+    # 8b plots
+    for pt in KBS128_PASSES:
+        _plot_group(
+            "kbs128",
+            KBS128_METHODS,
+            KBS128_LABELS,
+            pt,
+            f"kbs={KBS_BLOCK}",
+            f"kbs128_{pt}.png",
+        )
+
+    # Summary tables
     print("\n  " + "─" * 60)
-    print("  Summary Table (TFLOPS)")
+    print("  Summary Tables (TFLOPS)")
     print("  " + "─" * 60)
-    for sub, methods, labels in [
-        ("is", IS_METHODS, IS_METHOD_LABELS),
-        ("bs", BS_METHODS, BS_METHOD_LABELS),
+
+    for prefix, methods, labels, passes in [
+        ("kbs1", KBS1_METHODS, KBS1_LABELS, KBS1_PASSES),
+        ("kbs128", KBS128_METHODS, KBS128_LABELS, KBS128_PASSES),
     ]:
-        kbs_label = "kbs=1" if sub == "is" else f"kbs={KBS_BLOCK}"
-        for pass_type in PASSES:
-            print(f"\n  {pass_type.upper()} ({kbs_label}):")
+        for pt in passes:
+            print(f"\n  {pt.upper()} ({prefix}):")
             header = f"  {'S':>6s}"
             for m in methods:
-                header += f"  {labels[m]:>20s}"
+                header += f"  {labels[m]:>24s}"
             print(header)
             for S in SEQLEN_VALS:
                 row = f"  {S // 1024:>5d}k"
                 for m in methods:
-                    key = f"{sub}/{pass_type}/{m}"
+                    key = f"{prefix}/{pt}/{m}"
                     d = results.get(key, {})
                     if d and S in d.get("seqlen", []):
                         idx = d["seqlen"].index(S)
                         tf = d["tflops"][idx]
-                        row += f"  {tf:>20.1f}" if tf else f"  {'—':>20s}"
+                        row += f"  {tf:>24.1f}" if tf else f"  {'—':>24s}"
                     else:
-                        row += f"  {'—':>20s}"
+                        row += f"  {'—':>24s}"
                 print(row)

--- a/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
+++ b/exps/attn/sparse/bench_sparse_analysis/phase8_baseline_comparison.py
@@ -40,9 +40,9 @@ from bench_sparse_analysis._common import (
     HD,
     NHK,
     NHQ,
-    PLOT_BAR_ALPHA,
-    PLOT_BAR_WIDTH_RATIO,
-    PLOT_VALUE_FONTSIZE,
+    PLOT_DPI_SAVE,
+    PLOT_SUBPLOT_HEIGHT,
+    PLOT_SUBPLOT_WIDTH,
     VIDEO_SCENARIOS,
     _bench_kernel,
     _load_results,
@@ -50,6 +50,7 @@ from bench_sparse_analysis._common import (
     _save_results,
     _set_gpu,
     _ts,
+    plot_grouped_bars,
 )
 
 # ═══════════════════════════════════════════════════════════════
@@ -682,10 +683,9 @@ def _phase8_bench(force=False, rerun_filter=None):
 
 
 def _phase8_plot():
-    """Generate Phase-6 style grouped bar charts using _common plot constants.
+    """Generate Phase-6 style grouped bar charts via plot_grouped_bars().
 
-    Two figures: phase8a_kbs1.png and phase8b_kbs128.png.
-    Colors: our kernels use warm/saturated from _common; baselines use grey/dark.
+    Baselines (grey) on LEFT, our kernels (colored) on RIGHT — matching Phase 6.
     """
     import matplotlib
 
@@ -704,101 +704,100 @@ def _phase8_plot():
     kvseqlens = [s[0] for s in SCENARIOS]
     x = np.arange(len(kvseqlens))
     x_labels = [f"{kv // 1024}K\n(q={kv // 64}, top={kv // 8192}K)" for kv in kvseqlens]
+    xlabel = "kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)"
 
-    def _plot_figure(fig_id, prefix, plot_defs, pass_defs, title):
-        """Shared plotting logic for both 8a and 8b."""
-        n_cols = len(pass_defs)
-        fig, axes = plt.subplots(1, n_cols, figsize=(7 * n_cols, 7), dpi=150)
-        if n_cols == 1:
-            axes = [axes]
+    def _vals(prefix, pid, mid):
+        key = f"{prefix}/{pid}/{mid}"
+        d = results.get(key, {})
+        out_vals = []
+        for kv in kvseqlens:
+            if kv in d.get("kvseqlen", []):
+                idx = d["kvseqlen"].index(kv)
+                v = d["tflops"][idx] if d["tflops"][idx] else 0
+            else:
+                v = 0
+            out_vals.append(v)
+        return out_vals
 
-        for col_idx, (pid, pname) in enumerate(pass_defs):
-            ax = axes[col_idx]
-            n_m = len(plot_defs)
-            bw = PLOT_BAR_WIDTH_RATIO / n_m
-            for i, (mid, lbl, col) in enumerate(plot_defs):
-                key = f"{prefix}/{pid}/{mid}"
-                d = results.get(key, {})
-                vals = []
-                for kv in kvseqlens:
-                    if kv in d.get("kvseqlen", []):
-                        idx = d["kvseqlen"].index(kv)
-                        v = d["tflops"][idx] if d["tflops"][idx] else 0
-                    else:
-                        v = 0
-                    vals.append(v)
-                off = (i - n_m / 2 + 0.5) * bw
-                bars = ax.bar(
-                    x + off,
-                    vals,
-                    width=bw,
-                    label=lbl,
-                    color=col,
-                    edgecolor="white",
-                    linewidth=0.5,
-                    alpha=PLOT_BAR_ALPHA,
-                )
-                for bar, v in zip(bars, vals):
-                    if v > 0:
-                        ax.text(
-                            bar.get_x() + bar.get_width() / 2,
-                            bar.get_height() + 5,
-                            f"{v:.0f}",
-                            ha="center",
-                            va="bottom",
-                            fontsize=PLOT_VALUE_FONTSIZE,
-                            fontweight="bold",
-                        )
-
-            ax.set_title(pname, fontsize=13, fontweight="bold")
-            ax.set_xlabel("kvseqlen (qseqlen=kvseqlen/64, topk=kvseqlen/8)", fontsize=9)
-            ax.set_ylabel("TFLOPS", fontsize=12)
-            ax.set_xticks(x)
-            ax.set_xticklabels(x_labels, fontsize=9)
-            ax.tick_params(axis="y", labelsize=11)
-            ax.legend(loc="upper right", fontsize=9)
-            ax.grid(axis="y", alpha=0.3)
-
-        fig.suptitle(title, fontsize=13, fontweight="bold", y=1.02)
-        plt.tight_layout()
-        path = os.path.join(out, f"{fig_id}.png")
-        fig.savefig(path, dpi=180, bbox_inches="tight")
-        plt.close()
-        print(f"  Saved: {path}", flush=True)
-
-    # ── 8a) kbs=1 ──
-    _plot_figure(
-        "phase8a_kbs1",
-        "kbs1",
-        [
-            ("ffa_is", "FFA IndexSparse", COLOR_INDEX_SPARSE),
-            ("flexattn", "FlexAttention", COLOR_FLEXATTN),
-            ("triton", "Triton Token-Sparse", COLOR_TRITON),
-        ],
-        [("fwd", "FWD"), ("bwd", "BWD (LoopK)")],
+    # ── 8a) kbs=1: baselines LEFT, our kernel RIGHT ──
+    kbs1_pass_defs = [("fwd", "FWD"), ("bwd", "BWD (LoopK)")]
+    kbs1_methods = [
+        ("flexattn", "FlexAttention", COLOR_FLEXATTN),
+        ("triton", "Triton Token-Sparse", COLOR_TRITON),
+        ("ffa_is", "FFA IndexSparse", COLOR_INDEX_SPARSE),
+    ]
+    n_cols = len(kbs1_pass_defs)
+    fig, axes = plt.subplots(
+        1, n_cols, figsize=(PLOT_SUBPLOT_WIDTH * n_cols, PLOT_SUBPLOT_HEIGHT), dpi=150
+    )
+    if n_cols == 1:
+        axes = [axes]
+    for col_idx, (pid, pname) in enumerate(kbs1_pass_defs):
+        plot_grouped_bars(
+            axes[col_idx],
+            x,
+            kbs1_methods,
+            lambda mid, _pid=pid: _vals("kbs1", _pid, mid),
+            title=pname,
+            xlabel=xlabel,
+            x_labels=x_labels,
+        )
+    fig.suptitle(
         "Phase 8a: Token-Sparse Baseline (kbs=1)\n"
         f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
+        fontsize=14,
+        fontweight="bold",
+        y=1.02,
     )
+    plt.tight_layout()
+    p = os.path.join(out, "phase8a_kbs1.png")
+    fig.savefig(p, dpi=PLOT_DPI_SAVE, bbox_inches="tight")
+    plt.close()
+    print(f"  Saved: {p}", flush=True)
 
-    # ── 8b) kbs=128 ──
-    _plot_figure(
-        "phase8b_kbs128",
-        "kbs128",
-        [
-            ("ffa_bs", "FFA BlockSparse", COLOR_BLOCK_SPARSE),
-            ("ffa_is128", "FFA IndexSparse (kbs=128)", COLOR_INDEX_SPARSE),
-            ("flexattn", "FlexAttention", COLOR_FLEXATTN),
-            ("triton", "Triton Token-Sparse", COLOR_TRITON),
-        ],
-        [("fwd", "FWD"), ("bwd_loopk", "BWD LoopK"), ("bwd_loopq", "BWD LoopQ")],
+    # ── 8b) kbs=128: baselines LEFT, our kernels RIGHT ──
+    kbs128_pass_defs = [
+        ("fwd", "FWD"),
+        ("bwd_loopk", "BWD LoopK"),
+        ("bwd_loopq", "BWD LoopQ"),
+    ]
+    kbs128_methods = [
+        ("flexattn", "FlexAttention", COLOR_FLEXATTN),
+        ("triton", "Triton Token-Sparse", COLOR_TRITON),
+        ("ffa_bs", "FFA BlockSparse", COLOR_BLOCK_SPARSE),
+        ("ffa_is128", "FFA IndexSparse (kbs=128)", COLOR_INDEX_SPARSE),
+    ]
+    n_cols = len(kbs128_pass_defs)
+    fig, axes = plt.subplots(
+        1, n_cols, figsize=(PLOT_SUBPLOT_WIDTH * n_cols, PLOT_SUBPLOT_HEIGHT), dpi=150
+    )
+    for col_idx, (pid, pname) in enumerate(kbs128_pass_defs):
+        plot_grouped_bars(
+            axes[col_idx],
+            x,
+            kbs128_methods,
+            lambda mid, _pid=pid: _vals("kbs128", _pid, mid),
+            title=pname,
+            xlabel=xlabel,
+            x_labels=x_labels,
+        )
+    fig.suptitle(
         f"Phase 8b: Block-Sparse Baseline (kbs={KBS_BLOCK})\n"
         f"nhq={NHQ}, nhk={NHK}, hd={HD}, PackGQA, bf16, H100",
+        fontsize=14,
+        fontweight="bold",
+        y=1.02,
     )
+    plt.tight_layout()
+    p = os.path.join(out, "phase8b_kbs128.png")
+    fig.savefig(p, dpi=PLOT_DPI_SAVE, bbox_inches="tight")
+    plt.close()
+    print(f"  Saved: {p}", flush=True)
 
     # Summary tables
-    print("\n  " + "─" * 60)
+    print("\n  " + "\u2500" * 60)
     print("  Summary Tables (TFLOPS)")
-    print("  " + "─" * 60)
+    print("  " + "\u2500" * 60)
 
     for prefix, methods, labels, passes in [
         ("kbs1", KBS1_METHODS, KBS1_LABELS, KBS1_PASSES),
@@ -806,7 +805,7 @@ def _phase8_plot():
     ]:
         for pt in passes:
             print(f"\n  {pt.upper()} ({prefix}):")
-            header = f"  {'kvseqlen':>8s}"
+            header = "  " + f"{'kvseqlen':>8s}"
             for m in methods:
                 header += f"  {labels[m]:>24s}"
             print(header)
@@ -818,7 +817,7 @@ def _phase8_plot():
                     if d and kv in d.get("kvseqlen", []):
                         idx = d["kvseqlen"].index(kv)
                         tf = d["tflops"][idx]
-                        row += f"  {tf:>24.1f}" if tf else f"  {'—':>24s}"
+                        row += f"  {tf:>24.1f}" if tf else ("  " + "\u2014".rjust(24))
                     else:
-                        row += f"  {'—':>24s}"
+                        row += "  " + "\u2014".rjust(24)
                 print(row)


### PR DESCRIPTION
## 动机

将 IndexSparse 和 BlockSparse 与外部 baseline (FlexAttention, Triton Token-Sparse) 的性能对比统一纳入 `bench_sparse_analysis` 框架，复用 JSON 持久化、GPU 隔离检查、`--exp/--plot` CLI 等基础设施，消除原有独立脚本 (`run_index_sparse_comparison_benchmark.py`, `run_block_sparse_benchmark.py`) 的代码重复。

## 核心修改

1. **新增 Phase 8 基准对比** (`phase8_baseline_comparison.py`, 823 行)
   - **8a) kbs=1**: FFA IndexSparse vs FlexAttention vs Triton Token-Sparse (FWD + BWD LoopK)
   - **8b) kbs=128**: FFA BlockSparse vs FFA IndexSparse(128) vs FlexAttention vs Triton Token-Sparse (FWD + BWD LoopK + BWD LoopQ)
   - 场景与 Phase 6 Video Production 完全一致：`qseqlen=kvseqlen/64, topk=kvseqlen/8`
   - 含正确性验证 (`_sanity_check`) — 所有方法在 bench 前与 naive reference 对比

2. **提取公用绘图常量和 helper 到 `_common.py`** (+94 行)
   - 配色：`COLOR_INDEX_SPARSE`, `COLOR_BLOCK_SPARSE` (暖色), `COLOR_FLEXATTN`, `COLOR_TRITON` (灰色系)
   - 场景：`VIDEO_SCENARIOS` 共享于 Phase 6 & 8
   - 绘图参数：`PLOT_YLIM=(0,750)`, `PLOT_VALUE_FONTSIZE=6`, `PLOT_BAR_ALPHA=0.85` 等，与 Phase 6 一致
   - `plot_grouped_bars()` 通用分组柱状图渲染函数

## 基准结果 (H100, GPU0, 2026-07-17, commit a9e1d7b9)

### 8a) kbs=1 (TFLOPS)

| kvseqlen | pass | FlexAttn | Triton | **FFA IS** |
|---|---|----------|--------|--------|
| 32K | FWD | 373 | 438 | **480** |
| 64K | FWD | 388 | 466 | **528** |
| 128K | FWD | 402 | 452 | **495** |
| 256K | FWD | 404 | 457 | **503** |
| 512K | FWD | 398 | 441 | **483** |
| 32K | BWD | 134 | 43 | **246** |
| 64K | BWD | 220 | 44 | **266** |
| 128K | BWD | 248 | 43 | **277** |
| 256K | BWD | 257 | 43 | **276** |
| 512K | BWD | 269 | 43 | **276** |

### 8b) kbs=128 — FWD (TFLOPS)

| kvseqlen | FlexAttn | Triton | FFA BS | **FFA IS(128)** |
|---|----------|--------|--------|-------------|
| 32K | 376 | 438 | 254 | **625** |
| 64K | 391 | 465 | 478 | **681** |
| 128K | 399 | 454 | 600 | **629** |
| 256K | 403 | 452 | 615 | **638** |
| 512K | 396 | 409 | 614 | **642** |

### 8b) kbs=128 — BWD LoopK (TFLOPS)

| kvseqlen | FlexAttn | Triton | FFA BS | FFA IS(128) |
|---|----------|--------|--------|-------------|
| 32K | 188 | 43 | **320** | 322 |
| 64K | 216 | 44 | **350** | 351 |
| 128K | 251 | 41 | **353** | 353 |
| 256K | **257** | 39 | 198 | 198 |
| 512K | **268** | 38 | 163 | 163 |

### 8b) kbs=128 — BWD LoopQ (TFLOPS)

| kvseqlen | FlexAttn | Triton | **FFA BS** | FFA IS(128) |
|---|----------|--------|--------|-------------|
| 32K | 133 | 43 | **390** | 197 |
| 64K | 242 | 44 | **447** | 342 |
| 128K | 250 | 41 | **324** | 320 |
| 256K | 256 | 39 | **292** | 290 |
| 512K | 266 | 38 | **274** | 271 |

## 其他

- 正确性验证：所有方法在 (kvseqlen=2048, qseqlen=256, topk=256) 下通过
- Triton BWD 仅 ~43T — 朴素实现，无竞争力
- EffectiveKernels 已丢弃（nhk=16 GQA 限制、S>16K 崩溃）
- TileLang 不稳定暂未纳入

<!-- 图片占位：phase8a_kbs1.png, phase8b_kbs128.png -->
