### PR TITLE
fix: preserve derived mask runtime metadata

### DIFF
--- a/magi_attention/api/magi_attn_interface.py
+++ b/magi_attention/api/magi_attn_interface.py
@@ -1463,6 +1463,9 @@ def make_flex_key_for_new_mask_after_dispatch(
         overlap_config=dist_attn_config.overlap_config
         if dist_attn_config is not None
         else key_for_dispatch.dist_attn_config.overlap_config,
+        grpcoll_config=dist_attn_config.grpcoll_config
+        if dist_attn_config is not None
+        else key_for_dispatch.dist_attn_config.grpcoll_config,
     )
 
     # Extract the common attributes from the mgr for dispatch
@@ -1480,6 +1483,7 @@ def make_flex_key_for_new_mask_after_dispatch(
     num_heads_q = num_heads_q if num_heads_q is not None else mgr.num_heads_q
     num_heads_kv = num_heads_kv if num_heads_kv is not None else mgr.num_heads_kv
     head_dim = head_dim if head_dim is not None else mgr.head_dim
+    head_dim_v = key_for_dispatch.head_dim_v
 
     # Apply real padding to the new mask ranges (skip when uneven_shard)
     if uneven_shard:
@@ -1508,6 +1512,7 @@ def make_flex_key_for_new_mask_after_dispatch(
         cp_group=cp_group,
         cp_mesh=cp_mesh,
         dist_attn_config=new_dist_attn_config,
+        head_dim_v=head_dim_v,
     )
 
     # Init new dist attn runtime mgr and map it to the new key
@@ -1531,6 +1536,7 @@ def make_flex_key_for_new_mask_after_dispatch(
             is_k_permutable=is_k_permutable,
             ref_dispatch_meta_q=ref_dispatch_meta_q,
             ref_dispatch_meta_k=ref_dispatch_meta_k,
+            head_dim_v=head_dim_v,
         )
 
     return new_key

--- a/tests/test_api/test_interface.py
+++ b/tests/test_api/test_interface.py
@@ -44,6 +44,7 @@ from magi_attention.common.ranges import AttnRanges
 from magi_attention.config import (
     DispatchConfig,
     DistAttnConfig,
+    GrpCollConfig,
     MinHeapDispatchAlg,
     OverlapConfig,
     UniformOverlapAlg,
@@ -264,6 +265,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                 "total_seqlen_q": 1050,
                 "total_seqlen_k": 1050,
                 "chunk_size": 568,
+                "head_dim_v": 64,
             },
             # varlen block causal with total seqlen 960
             {
@@ -428,6 +430,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
         total_seqlen_k: int = attn_config["total_seqlen_k"]
         chunk_size: int = attn_config["chunk_size"]
         num_heads_q, num_heads_kv = num_heads
+        head_dim_v: int | None = attn_config.get("head_dim_v")
 
         dist_attn_config = DistAttnConfig(
             # TODO: test other dispatch algs
@@ -498,6 +501,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                     else self.nccl_group,
                     causal=is_causal,
                     dist_attn_config=dist_attn_config,
+                    head_dim_v=head_dim_v,
                 )
             case "magi_attn_varlen":
                 assert is_list_value_all(
@@ -522,6 +526,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                     else self.nccl_group,
                     causal=is_causal,
                     dist_attn_config=dist_attn_config,
+                    head_dim_v=head_dim_v,
                 )
             case "magi_attn_flex":
                 use_str_masktype: bool = attn_config["use_str_masktype"]
@@ -542,6 +547,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                     if env.comm.is_hierarchical_comm_enable()
                     else self.nccl_group,
                     dist_attn_config=dist_attn_config,
+                    head_dim_v=head_dim_v,
                 )
                 local_x_padded = dispatch(x, key=dist_attn_runtime_key)
             case "set_mesh_and_group":
@@ -627,6 +633,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
             cp_group=self.nccl_group,
             cp_mesh=self.device_mesh,
             dist_attn_config=dist_attn_config,
+            head_dim_v=head_dim_v,
         )
 
         # -------   check mgr equality to ref -------- #
@@ -671,7 +678,9 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                     AttnMaskType.from_int_type(new_attn_type_mapping)
                 ] * len(new_q_ranges)
 
-            new_dist_attn_config = DistAttnConfig()
+            new_dist_attn_config = DistAttnConfig(
+                grpcoll_config=GrpCollConfig(num_sms=8)
+            )
 
             match interface:
                 case "magi_attn_varlen":
@@ -707,6 +716,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
             assert new_key.total_seqlen_q == dist_attn_runtime_key.total_seqlen_q
             assert new_key.total_seqlen_k == dist_attn_runtime_key.total_seqlen_k
             assert new_key.dist_attn_config == new_dist_attn_config
+            assert new_key.head_dim_v == head_dim_v
 
             new_mgr: DistAttnRuntimeMgr = dist_attn_runtime_dict_mgr[new_key]
             ref_new_mgr = init_dist_attn_runtime_mgr(
@@ -724,6 +734,7 @@ class TestInterfaceBaseWithWorldSize1(DistTestBase):
                 dist_attn_config=new_dist_attn_config,
                 ref_dispatch_meta_q=dist_attn_runtime_mgr.dispatch_meta_q,
                 ref_dispatch_meta_k=dist_attn_runtime_mgr.dispatch_meta_k,
+                head_dim_v=head_dim_v,
             )
             assert (
                 new_mgr == ref_new_mgr


### PR DESCRIPTION
## Summary

- Preserve asymmetric value-head dimensions when deriving a key for a new mask after dispatch.
- Retain the selected group-collective configuration while reusing dispatch metadata.
- Cover derived keys with an asymmetric V dimension and a non-default group-collective configuration.

## Checks

- `git diff --check`
- `python -m compileall -q magi_attention/api/magi_attn_interface.py tests/test_api/test_interface.py`
