### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ We sincerely thank the NVIDIA DevTech team—especially Jerry Chen <cjerry@nvidi
 ## Star History ⭐
 
 <div align="center">
-  <a href="https://star-history.com/#SandAI-org/MagiAttention&Date">
-    <img src="https://api.star-history.com/svg?repos=SandAI-org/MagiAttention&type=Date" alt="Star History Chart" style="max-width: 60%; height: auto;"/>
+  <a href="https://star-history.dera.page/#SandAI-org/MagiAttention&Date">
+    <img src="https://star-history.dera.page/svg?repos=SandAI-org/MagiAttention&type=Date" alt="Star History Chart" style="max-width: 60%; height: auto;"/>
   </a>
 </div>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This PR switches it to an alternative service that uses a different, token-free data source so the chart renders correctly again.